### PR TITLE
Error handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin is available as a Python package in PyPI and can be installed with pi
 pip install nautobot-netbox-importer
 ```
 
-> The plugin is compatible with Nautobot 1.0 and can handle JSON data exported from NetBox 2.10.3 and 2.10.4 at present.
+> The plugin is compatible with Nautobot 1.0 and can handle JSON data exported from NetBox 2.10.3 through 2.10.5 at present.
 
 Once installed, the plugin needs to be enabled in your `nautobot_config.py`:
 

--- a/nautobot_netbox_importer/diffsync/adapters/__init__.py
+++ b/nautobot_netbox_importer/diffsync/adapters/__init__.py
@@ -8,6 +8,7 @@ from .netbox import NetBox210DiffSync
 netbox_adapters = {
     version.parse("2.10.3"): NetBox210DiffSync,
     version.parse("2.10.4"): NetBox210DiffSync,
+    version.parse("2.10.5"): NetBox210DiffSync,
 }
 
 __all__ = (

--- a/nautobot_netbox_importer/diffsync/adapters/abstract.py
+++ b/nautobot_netbox_importer/diffsync/adapters/abstract.py
@@ -189,9 +189,9 @@ class N2NDiffSync(DiffSync):
         "interface",
         "vminterface",
         # Reference loop:
-        #   Device -> IPAddress (primary_ip)
-        #   IPAddress -> Interface (assigned_object)
-        #   Interface -> Device (device)
+        #   Device/VirtualMachine -> IPAddress (primary_ip4/primary_ip6)
+        #   IPAddress -> Interface/VMInterface (assigned_object)
+        #   Interface/VMInterface -> Device/VirtualMachine (device)
         # Interface comes after Device because it MUST have a Device to be created;
         # IPAddress comes after Interface because we use the assigned_object as part of the IP's unique ID.
         # We will fixup the Device->primary_ip reference in fixup_data_relations()

--- a/nautobot_netbox_importer/diffsync/adapters/abstract.py
+++ b/nautobot_netbox_importer/diffsync/adapters/abstract.py
@@ -139,14 +139,6 @@ class N2NDiffSync(DiffSync):
         "site",  # Not all Sites belong to a Region
         "manufacturer",
         "devicetype",
-        "consoleporttemplate",
-        "consoleserverporttemplate",
-        "powerporttemplate",
-        "poweroutlettemplate",
-        "rearporttemplate",
-        "frontporttemplate",
-        "interfacetemplate",
-        "devicebaytemplate",
         "devicerole",
         "platform",
         "clustertype",
@@ -172,6 +164,17 @@ class N2NDiffSync(DiffSync):
         "prefix",
         # Lots of pre-requisites for constructing a Device!
         "device",
+        # Create device component templates **after** creating Devices,
+        # as otherwise the created Devices will all use the fully-populated templates,
+        # and we want to ensure that the Devices have only the components we have identified!
+        "consoleporttemplate",
+        "consoleserverporttemplate",
+        "powerporttemplate",
+        "poweroutlettemplate",
+        "rearporttemplate",
+        "frontporttemplate",
+        "interfacetemplate",
+        "devicebaytemplate",
         # All device components require a parent Device
         "devicebay",
         "inventoryitem",

--- a/nautobot_netbox_importer/diffsync/adapters/abstract.py
+++ b/nautobot_netbox_importer/diffsync/adapters/abstract.py
@@ -285,12 +285,24 @@ class N2NDiffSync(DiffSync):
         try:
             instance = diffsync_model(**data, diffsync=self)
         except ValidationError as exc:
-            self.logger.error(str(exc))
+            self.logger.error(
+                "Invalid data according to internal data model. "
+                "This may be an issue with your source data or may reflect a bug in this plugin.",
+                action="load",
+                exception=str(exc),
+                model=diffsync_model,
+                model_data=data,
+            )
             return None
         try:
             self.add(instance)
         except ObjectAlreadyExists:
-            self.logger.warning("Apparent duplicate object encountered", model=instance)
+            self.logger.warning(
+                "Apparent duplicate object encountered. "
+                "This may be an issue with your source data or may reflect a bug in this plugin.",
+                model=instance,
+                model_id=instance.get_unique_id(),
+            )
         return instance
 
     def sync_from(self, source: DiffSync, diff_class: Diff = Diff, flags: DiffSyncFlags = DiffSyncFlags.NONE):

--- a/nautobot_netbox_importer/diffsync/models/abstract.py
+++ b/nautobot_netbox_importer/diffsync/models/abstract.py
@@ -437,4 +437,9 @@ class ArrayField(DiffSyncCustomValidationField, list):
             value = [int(item) for item in value]
         except ValueError:
             pass
+        # Additionally, NetBox may store a list of ints in arbitrary (unsorted) order.
+        # For consistent behavior, sort them:
+        # TODO: this *should* be okay in all cases as I don't know of any ArrayFields
+        #       in NetBox or Nautobot where maintaining order is relevant.
+        value = sorted(value)
         return cls(value)

--- a/nautobot_netbox_importer/diffsync/models/abstract.py
+++ b/nautobot_netbox_importer/diffsync/models/abstract.py
@@ -198,7 +198,7 @@ class NautobotBaseModel(DiffSyncModel):
                 action="create",
                 exception=str(exc),
                 model=nautobot_model,
-                model_data=dict(**ids, **attrs, **multivalue_attrs)
+                model_data=dict(**ids, **attrs, **multivalue_attrs),
             )
         except DjangoValidationError as exc:
             logger.error(

--- a/nautobot_netbox_importer/diffsync/models/dcim.py
+++ b/nautobot_netbox_importer/diffsync/models/dcim.py
@@ -418,7 +418,7 @@ class PowerOutletTemplate(ComponentTemplateModel):
     _attributes = (*ComponentTemplateModel._attributes, "type", "power_port", "feed_leg")
     _nautobot_model = dcim.PowerOutletTemplate
 
-    type: staticmethod
+    type: str
     power_port: Optional[PowerPortTemplateRef]
     feed_leg: str
 

--- a/nautobot_netbox_importer/diffsync/models/dcim.py
+++ b/nautobot_netbox_importer/diffsync/models/dcim.py
@@ -125,47 +125,65 @@ class Device(ConfigContextModelMixin, StatusModelMixin, PrimaryModel):
     """A Device represents a piece of physical hardware mounted within a Rack."""
 
     _modelname = "device"
-    _identifiers = ("site", "tenant", "name")
-    _attributes = (
-        *PrimaryModel._attributes,
-        *ConfigContextModelMixin._attributes,
-        *StatusModelMixin._attributes,
+    # Although dcim.Device defines (site, tenant, name) as a unique_together constraint,
+    # multiple devices in the same site/tenant may coexist with a NULL name because NULL != NULL.
+    # Similarly (rack, position, face) is unique_together but multiple un-racked devices may coexist.
+    # Similarly (virtual_chassis, vc_position) is unique_together but multiple non-vc devices may coexist.
+    # In short, to avoid treating distinct Device records incorrectly as duplicates, we
+    # need to consider **most attributes** as "identifiers" of a unique Device.
+    _identifiers = (
+        "site",
+        "tenant",
+        "name",
+        "rack",
+        "position",
+        "face",
+        "vc_position",
+        "vc_priority",
         "device_type",
         "device_role",
         "platform",
         "serial",
         "asset_tag",
-        "rack",
-        "position",
-        "face",
+        "cluster",
+    )
+    _attributes = (
+        *PrimaryModel._attributes,
+        *ConfigContextModelMixin._attributes,
+        *StatusModelMixin._attributes,
+        # Due to model loading order, VirtualChassis references will initially be None and
+        # will only later be set; since a model's identifiers may not change after instantiation,
+        # we cannot treat this as an identifier.
+        "virtual_chassis",
+        # Due to model loading order, IPAddress references will initially be None and will
+        # only later be set; since a model's identifiers may not change after instantiation,
+        # we cannot treat these as identifiers.
         "primary_ip4",
         "primary_ip6",
-        "cluster",
-        "virtual_chassis",
-        "vc_position",
-        "vc_priority",
+        # Highly unlikely that two Devices will be identical in all respects save their comments;
+        # plus comments are the field most likely to change between subsequent data imports.
         "comments",
     )
     _nautobot_model = dcim.Device
 
     site: Optional[SiteRef]
     tenant: Optional[TenantRef]
-    name: str
-
+    name: Optional[str]
+    rack: Optional[RackRef]
+    position: Optional[int]
+    face: str  # may not be None but may be empty
+    vc_position: Optional[int]
+    vc_priority: Optional[int]
     device_type: DeviceTypeRef
     device_role: DeviceRoleRef
     platform: Optional[PlatformRef]
-    serial: str
+    serial: str  # may not be None but may be empty
     asset_tag: Optional[str]
-    rack: Optional[RackRef]
-    position: Optional[int]
-    face: str
+    cluster: Optional[ClusterRef]
+
+    virtual_chassis: Optional[VirtualChassisRef]
     primary_ip4: Optional[IPAddressRef]
     primary_ip6: Optional[IPAddressRef]
-    cluster: Optional[ClusterRef]
-    virtual_chassis: Optional[VirtualChassisRef]
-    vc_position: Optional[int]
-    vc_priority: Optional[int]
     comments: str
 
 

--- a/nautobot_netbox_importer/diffsync/models/ipam.py
+++ b/nautobot_netbox_importer/diffsync/models/ipam.py
@@ -12,6 +12,7 @@ import netaddr
 import nautobot.ipam.models as ipam
 
 from .abstract import (
+    ArrayField,
     OrganizationalModel,
     PrimaryModel,
     StatusModelMixin,
@@ -173,7 +174,7 @@ class Service(PrimaryModel):
     device: Optional[DeviceRef]
     virtual_machine: Optional[VirtualMachineRef]
     protocol: str
-    ports: List[int]
+    ports: ArrayField
 
     name: str
     ipaddresses: List[IPAddressRef]

--- a/nautobot_netbox_importer/diffsync/models/ipam.py
+++ b/nautobot_netbox_importer/diffsync/models/ipam.py
@@ -222,11 +222,9 @@ class VRF(PrimaryModel):
     """A virtual routing and forwarding (VRF) table."""
 
     _modelname = "vrf"
-    _identifiers = ("rd",)
+    _identifiers = ("name", "rd", "tenant")
     _attributes = (
         *PrimaryModel._attributes,
-        "name",
-        "tenant",
         "enforce_unique",
         "description",
         "import_targets",
@@ -234,9 +232,10 @@ class VRF(PrimaryModel):
     )
     _nautobot_model = ipam.VRF
 
-    rd: str
     name: str
+    rd: Optional[str]
     tenant: Optional[TenantRef]
+
     enforce_unique: bool
     description: str
     import_targets: List[RouteTargetRef] = []

--- a/nautobot_netbox_importer/management/commands/import_netbox_json.py
+++ b/nautobot_netbox_importer/management/commands/import_netbox_json.py
@@ -83,6 +83,7 @@ class Command(BaseCommand):
         target = NautobotDiffSync()
         target.load()
 
+        logger.info("Beginning data synchronization...")
         # Due to the fact that model inter-references do not form an acyclic graph,
         # there is no ordering of models that we can follow that allows for the creation
         # of all possible references in a single linear pass.

--- a/nautobot_netbox_importer/management/commands/import_netbox_json.py
+++ b/nautobot_netbox_importer/management/commands/import_netbox_json.py
@@ -64,8 +64,8 @@ class Command(BaseCommand):
         """Handle execution of the import_netbox_json management command."""
         if options["netbox_version"] < version.Version("2.10.3"):
             raise CommandError("Minimum NetBox version supported is 2.10.3")
-        if options["netbox_version"] > version.Version("2.10.4"):
-            raise CommandError("Maximum NetBox version supported is 2.10.4")
+        if options["netbox_version"] > version.Version("2.10.5"):
+            raise CommandError("Maximum NetBox version supported is 2.10.5")
 
         self.enable_logging(verbosity=options["verbosity"])
         logger = structlog.get_logger()

--- a/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
+++ b/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
@@ -3437,6 +3437,108 @@
 #     origin_type: 3
 #     path: '["46:8"]'
 #   model: dcim.cablepath
+- model: dcim.consoleporttemplate
+  ids:
+    name: "Console Port 1"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Model A Console Port 1"
+    description: "Console Port template for Model A"
+    type: "rj-45"
+- model: dcim.consoleserverporttemplate
+  ids:
+    name: "Console Server Port 1"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Model A Console Server Port 1"
+    description: "Console Server Port template for Model A"
+    type: "rj-45"
+- model: dcim.powerporttemplate
+  ids:
+    name: "Power Port 1"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Model A Power Port 1"
+    description: "Power Port template for Model A"
+    type: "nema-5-15p"
+    maximum_draw: 100
+    allocated_draw: 10
+- model: dcim.poweroutlettemplate
+  ids:
+    name: "Power Outlet 1"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Model A Power Outlet 1"
+    description: "Power Outlet template for Model A"
+    type: "nema-5-30r"
+    power_port:
+      ids:
+        name: "Power Port 1"
+    feed_leg: "A"
+- model: dcim.interfacetemplate
+  ids:
+    name: "mgmt0"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Management 0"
+    description: "Management interface template for Model A"
+    type: "1000base-t"
+    mgmt_only: true
+- model: dcim.interfacetemplate
+  ids:
+    name: "eth0"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Ethernet 0"
+    description: "Ethernet interface template for Model A"
+    type: "100base-tx"
+    mgmt_only: false
+- model: dcim.frontporttemplate
+  ids:
+    name: "Front Port 1"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Model A Front Port 1"
+    description: "Front Port template for Model A"
+    type: "8p8c"
+    rear_port:
+      ids:
+        name: "Rear Port 1"
+    rear_port_position: 1
+- model: dcim.rearporttemplate
+  ids:
+    name: "Rear Port 1"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Model A Rear Port 1"
+    description: "Rear Port template for Model A"
+    type: "8p8c"
+    positions: 2
+- model: dcim.devicebaytemplate
+  ids:
+    name: "Device Bay 1"
+  fields:
+    device_type:
+      ids:
+        model: "Model A"
+    label: "Model A Device Bay 1"
+    description: "Device bay template for Model A"
 - model: dcim.powerpanel
   ids:
     name: Power Panel A
@@ -3776,6 +3878,28 @@
     tenant:
       ids:
         name: "Tenant B"
+- model: ipam.aggregate
+  ids:
+    prefix: "fe80::/10"
+  fields:
+    custom_field_data: {}
+    date_added: "2021-03-08"
+    description: "Link-local addresses"
+    rir:
+      ids:
+        name: "RIR A"
+    tenant: null
+- model: ipam.aggregate
+  ids:
+    prefix: "2001:db8::/32"
+  fields:
+    custom_field_data: {}
+    date_added: "2021-03-08"
+    description: ""
+    rir:
+      ids:
+        name: "RIR B"
+    tenant: null
 - model: ipam.role
   ids:
     name: Role A
@@ -3859,6 +3983,46 @@
     vrf:
       ids:
         name: "VRF B"
+- model: ipam.prefix
+  ids:
+    prefix: "fe80::/64"
+  fields:
+    custom_field_data: {}
+    description: ""
+    is_pool: false
+    role: null
+    site: null
+    status:
+      ids:
+        slug: "active"
+    tenant: null
+    vlan: null
+    vrf: null
+- model: ipam.prefix
+  ids:
+    prefix: "2001:db8:0:1::/64"
+  fields:
+    custom_field_data: {}
+    description: ""
+    is_pool: false
+    role:
+      ids:
+        name: "Role B"
+    site:
+      ids:
+        name: "Site B"
+    status:
+      ids:
+        slug: "active"
+    tenant:
+      ids:
+        name: "Tenant B"
+    vlan:
+      ids:
+        name: "VLAN B"
+    vrf:
+      ids:
+        name: "VRF B"
 - model: ipam.ipaddress
   ids:
     address: 10.1.1.1/32
@@ -3907,6 +4071,91 @@
     vrf:
       ids:
         name: "VRF A"
+- model: ipam.ipaddress
+  ids:
+    address: 10.1.1.3/24
+  fields:
+    # TODO assigned_object_id
+    assigned_object_type:
+      ids:
+        app_label: "virtualization"
+        model: "vminterface"
+    custom_field_data: {}
+    description: ""
+    dns_name: ""
+    nat_inside: null
+    role: ""
+    status:
+      ids:
+        slug: "active"
+    tenant: null
+    vrf: null
+- model: ipam.ipaddress
+  ids:
+    address: "fe80::1c46:231c:ce55:25dd/128"
+  fields:
+    # TODO assigned_object_id
+    assigned_object_type:
+      ids:
+        app_label: "virtualization"
+        model: "vminterface"
+    custom_field_data: {}
+    description: ""
+    dns_name: "centos"
+    nat_inside: null
+    role: ""
+    status:
+      ids:
+        slug: "active"
+    tenant:
+      ids:
+        name: "Tenant B"
+    vrf:
+      ids:
+        name: "VRF B"
+- model: ipam.ipaddress
+  ids:
+    address: "2001:db8:0:1:1::1/80"
+  fields:
+    # TODO assigned_object_id
+    assigned_object_type:
+      ids:
+        app_label: "virtualization"
+        model: "vminterface"
+    custom_field_data: {}
+    description: ""
+    dns_name: ""
+    nat_inside: null
+    role: ""
+    status:
+      ids:
+        slug: "active"
+    tenant:
+      ids:
+        name: "Tenant B"
+    vrf:
+      ids:
+        name: "VRF B"
+- model: ipam.ipaddress
+  ids:
+    address: "2001:db8:0:1::1/64"
+  fields:
+    assigned_object_id: null
+    assigned_object_type: null
+    custom_field_data: {}
+    description: ""
+    dns_name: ""
+    nat_inside: null
+    role: ""
+    status:
+      ids:
+        slug: "active"
+    tenant:
+      ids:
+        name: "Tenant B"
+    vrf:
+      ids:
+        name: "VRF B"
 - model: ipam.vlangroup
   ids:
     name: VLAN Group A
@@ -3969,6 +4218,34 @@
       ids:
         name: "Tenant B"
     vid: 2
+- model: ipam.service
+  ids:
+    name: "Service A"
+  fields:
+    custom_field_data: {}
+    description: "Service A on VM A"
+    device: null
+    ipaddresses:
+      - ids:
+          address: "10.1.1.3/24"
+    ports: [80, 8080, 10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10009, 10010]
+    protocol: "tcp"
+    virtual_machine:
+      ids:
+        name: "VM A"
+- model: ipam.service
+  ids:
+    name: "Service B"
+  fields:
+    custom_field_data: {}
+    description: ""
+    device: null
+    ipaddresses: []
+    ports: [12345]
+    protocol: "udp"
+    virtual_machine:
+      ids:
+        name: "VM B"
 - model: extras.customfield
   ids:
     name: Custom Text Field A
@@ -4496,16 +4773,17 @@
     tag:
       ids:
         name: "Tag A"
-- model: extras.taggeditem
-  ids:
-    content_type:
-      ids:
-        app_label: "ipam"
-        model: "aggregate"
+# TODO: need object_id to distinguish between two aggregates tagged with Tag B
+# - model: extras.taggeditem
+#   ids:
+#     content_type:
+#       ids:
+#         app_label: "ipam"
+#         model: "aggregate"
 # TODO    object_id: 2
-    tag:
-      ids:
-        name: "Tag B"
+#     tag:
+#       ids:
+#         name: "Tag B"
 # TODO: need object_id to distinguish between two prefix tagged with Tag A
 # - model: extras.taggeditem
 #   ids:
@@ -4527,16 +4805,17 @@
 #     tag:
 #       ids:
 #         name: "Tag A"
-- model: extras.taggeditem
-  ids:
-    content_type:
-      ids:
-        app_label: "ipam"
-        model: "prefix"
+# TODO: need object_id to distinguish between two prefix tagged with Tag B
+# - model: extras.taggeditem
+#   ids:
+#     content_type:
+#       ids:
+#         app_label: "ipam"
+#         model: "prefix"
 # TODO    object_id: 3
-    tag:
-      ids:
-        name: "Tag B"
+#     tag:
+#       ids:
+#         name: "Tag B"
 # TODO: need object_id to distinguish between two ipaddress tagged with Tag A
 # - model: extras.taggeditem
 #   ids:
@@ -4558,6 +4837,17 @@
 #     tag:
 #       ids:
 #         name: "Tag A"
+# TODO: need object_id to distinguish between two ipaddress tagged with Tag B
+# - model: extras.taggeditem
+#   ids:
+#     content_type:
+#       ids:
+#         app_label: "ipam"
+#         model: "ipaddress"
+# TODO: object_id
+#     tag:
+#       ids:
+#         name: "Tag B"
 - model: extras.taggeditem
   ids:
     content_type:
@@ -4676,6 +4966,26 @@
         app_label: "dcim"
         model: "powerfeed"
 # TODO    object_id: 2
+    tag:
+      ids:
+        name: "Tag B"
+- model: extras.taggeditem
+  ids:
+    content_type:
+      ids:
+        app_label: "ipam"
+        model: "service"
+# TODO object_id: 1
+    tag:
+      ids:
+        name: "Tag A"
+- model: extras.taggeditem
+  ids:
+    content_type:
+      ids:
+        app_label: "ipam"
+        model: "service"
+# TODO object_id: 2
     tag:
       ids:
         name: "Tag B"
@@ -4974,7 +5284,9 @@
     platform:
       ids:
         name: "Platform A"
-    primary_ip4: null
+    primary_ip4:
+      ids:
+        address: "10.1.1.3/24"
     primary_ip6: null
     role:
       ids:
@@ -5002,7 +5314,9 @@
       ids:
         name: "Platform B"
     primary_ip4: null
-    primary_ip6: null
+    primary_ip6:
+      ids:
+        address: "2001:db8:0:1:1::1/80"
     role:
       ids:
         name: "Device Role B"

--- a/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
+++ b/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
@@ -2992,7 +2992,7 @@
         "pk": 1,
         "fields": {
             "password": "pbkdf2_sha256$216000$da6CZRwS7Ti6$GIUYlTXeEOyZIuEgQTEkohHnvmd3kDn0OCyuT1dM+H4=",
-            "last_login": "2021-02-21T23:25:39.132Z",
+            "last_login": "2021-03-08T14:35:56.453Z",
             "is_superuser": true,
             "username": "admin",
             "first_name": "Andy",
@@ -4780,6 +4780,122 @@
         }
     },
     {
+        "model": "dcim.consoleporttemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "Console Port 1",
+            "_name": "Console Port 00000001",
+            "label": "Model A Console Port 1",
+            "description": "Console Port template for Model A",
+            "type": "rj-45"
+        }
+    },
+    {
+        "model": "dcim.consoleserverporttemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "Console Server Port 1",
+            "_name": "Console Server Port 00000001",
+            "label": "Model A Console Server Port 1",
+            "description": "Console Server Port template for Model A",
+            "type": "rj-45"
+        }
+    },
+    {
+        "model": "dcim.powerporttemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "Power Port 1",
+            "_name": "Power Port 00000001",
+            "label": "Model A Power Port 1",
+            "description": "Power Port template for Model A",
+            "type": "nema-5-15p",
+            "maximum_draw": 100,
+            "allocated_draw": 10
+        }
+    },
+    {
+        "model": "dcim.poweroutlettemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "Power Outlet 1",
+            "_name": "Power Outlet 00000001",
+            "label": "Model A Power Outlet 1",
+            "description": "Power Outlet template for Model A",
+            "type": "nema-5-30r",
+            "power_port": 1,
+            "feed_leg": "A"
+        }
+    },
+    {
+        "model": "dcim.interfacetemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "mgmt0",
+            "label": "Management 0",
+            "description": "Management interface template for Model A",
+            "_name": "9999999999999999mgmt000000............",
+            "type": "1000base-t",
+            "mgmt_only": true
+        }
+    },
+    {
+        "model": "dcim.interfacetemplate",
+        "pk": 2,
+        "fields": {
+            "device_type": 1,
+            "name": "eth0",
+            "label": "Ethernet 0",
+            "description": "Ethernet interface template for Model A",
+            "_name": "9999999999999999eth000000............",
+            "type": "100base-tx",
+            "mgmt_only": false
+        }
+    },
+    {
+        "model": "dcim.frontporttemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "Front Port 1",
+            "_name": "Front Port 00000001",
+            "label": "Model A Front Port 1",
+            "description": "Front Port template for Model A",
+            "type": "8p8c",
+            "rear_port": 1,
+            "rear_port_position": 1
+        }
+    },
+    {
+        "model": "dcim.rearporttemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "Rear Port 1",
+            "_name": "Rear Port 00000001",
+            "label": "Model A Rear Port 1",
+            "description": "Rear Port template for Model A",
+            "type": "8p8c",
+            "positions": 2
+        }
+    },
+    {
+        "model": "dcim.devicebaytemplate",
+        "pk": 1,
+        "fields": {
+            "device_type": 1,
+            "name": "Device Bay 1",
+            "_name": "Device Bay 00000001",
+            "label": "Model A Device Bay 1",
+            "description": "Device bay template for Model A"
+        }
+    },
+    {
         "model": "dcim.powerpanel",
         "pk": 1,
         "fields": {
@@ -5182,6 +5298,34 @@
         }
     },
     {
+        "model": "ipam.aggregate",
+        "pk": 3,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:52:50.511Z",
+            "custom_field_data": {},
+            "prefix": "fe80::/10",
+            "rir": 1,
+            "tenant": null,
+            "date_added": "2021-03-08",
+            "description": "Link-local addresses"
+        }
+    },
+    {
+        "model": "ipam.aggregate",
+        "pk": 4,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:57:24.148Z",
+            "custom_field_data": {},
+            "prefix": "2001:db8::/32",
+            "rir": 2,
+            "tenant": null,
+            "date_added": "2021-03-08",
+            "description": ""
+        }
+    },
+    {
         "model": "ipam.role",
         "pk": 1,
         "fields": {
@@ -5260,6 +5404,42 @@
         }
     },
     {
+        "model": "ipam.prefix",
+        "pk": 4,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:53:46.782Z",
+            "custom_field_data": {},
+            "prefix": "fe80::/64",
+            "site": null,
+            "vrf": null,
+            "tenant": null,
+            "vlan": null,
+            "status": "active",
+            "role": null,
+            "is_pool": false,
+            "description": ""
+        }
+    },
+    {
+        "model": "ipam.prefix",
+        "pk": 5,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:57:58.548Z",
+            "custom_field_data": {},
+            "prefix": "2001:db8:0:1::/64",
+            "site": 2,
+            "vrf": 2,
+            "tenant": 2,
+            "vlan": 2,
+            "status": "active",
+            "role": 2,
+            "is_pool": false,
+            "description": ""
+        }
+    },
+    {
         "model": "ipam.ipaddress",
         "pk": 1,
         "fields": {
@@ -5295,6 +5475,82 @@
             "nat_inside": 1,
             "dns_name": "",
             "description": "A"
+        }
+    },
+    {
+        "model": "ipam.ipaddress",
+        "pk": 3,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:49:34.798Z",
+            "custom_field_data": {},
+            "address": "10.1.1.3/24",
+            "vrf": null,
+            "tenant": null,
+            "status": "active",
+            "role": "",
+            "assigned_object_type": 8,
+            "assigned_object_id": 1,
+            "nat_inside": null,
+            "dns_name": "",
+            "description": ""
+        }
+    },
+    {
+        "model": "ipam.ipaddress",
+        "pk": 4,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:55:18.841Z",
+            "custom_field_data": {},
+            "address": "fe80::1c46:231c:ce55:25dd/128",
+            "vrf": 2,
+            "tenant": 2,
+            "status": "active",
+            "role": "",
+            "assigned_object_type": 8,
+            "assigned_object_id": 2,
+            "nat_inside": null,
+            "dns_name": "centos",
+            "description": ""
+        }
+    },
+    {
+        "model": "ipam.ipaddress",
+        "pk": 5,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T15:01:17.823Z",
+            "custom_field_data": {},
+            "address": "2001:db8:0:1:1::1/80",
+            "vrf": 2,
+            "tenant": 2,
+            "status": "active",
+            "role": "",
+            "assigned_object_type": 8,
+            "assigned_object_id": 2,
+            "nat_inside": null,
+            "dns_name": "",
+            "description": ""
+        }
+    },
+    {
+        "model": "ipam.ipaddress",
+        "pk": 6,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T15:00:15.881Z",
+            "custom_field_data": {},
+            "address": "2001:db8:0:1::1/64",
+            "vrf": 2,
+            "tenant": 2,
+            "status": "active",
+            "role": "",
+            "assigned_object_type": null,
+            "assigned_object_id": null,
+            "nat_inside": null,
+            "dns_name": "",
+            "description": ""
         }
     },
     {
@@ -5353,6 +5609,40 @@
             "status": "active",
             "role": 2,
             "description": ""
+        }
+    },
+    {
+        "model": "ipam.service",
+        "pk": 1,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:50:08.435Z",
+            "custom_field_data": {},
+            "device": null,
+            "virtual_machine": 1,
+            "name": "Service A",
+            "protocol": "tcp",
+            "ports": "[\"10007\", \"80\", \"10001\", \"10002\", \"10003\", \"8080\", \"10004\", \"10005\", \"10006\", \"10008\", \"10009\", \"10010\"]",
+            "description": "Service A on VM A",
+            "ipaddresses": [
+                3
+            ]
+        }
+    },
+    {
+        "model": "ipam.service",
+        "pk": 2,
+        "fields": {
+            "created": "2021-03-08",
+            "last_updated": "2021-03-08T14:50:41.786Z",
+            "custom_field_data": {},
+            "device": null,
+            "virtual_machine": 2,
+            "name": "Service B",
+            "protocol": "udp",
+            "ports": "[\"12345\"]",
+            "description": "",
+            "ipaddresses": []
         }
     },
     {
@@ -6007,6 +6297,60 @@
         }
     },
     {
+        "model": "extras.taggeditem",
+        "pk": 66,
+        "fields": {
+            "content_type": 57,
+            "object_id": 1,
+            "tag": 1
+        }
+    },
+    {
+        "model": "extras.taggeditem",
+        "pk": 67,
+        "fields": {
+            "content_type": 57,
+            "object_id": 2,
+            "tag": 2
+        }
+    },
+    {
+        "model": "extras.taggeditem",
+        "pk": 68,
+        "fields": {
+            "content_type": 50,
+            "object_id": 4,
+            "tag": 2
+        }
+    },
+    {
+        "model": "extras.taggeditem",
+        "pk": 69,
+        "fields": {
+            "content_type": 49,
+            "object_id": 4,
+            "tag": 2
+        }
+    },
+    {
+        "model": "extras.taggeditem",
+        "pk": 70,
+        "fields": {
+            "content_type": 51,
+            "object_id": 5,
+            "tag": 2
+        }
+    },
+    {
+        "model": "extras.taggeditem",
+        "pk": 71,
+        "fields": {
+            "content_type": 50,
+            "object_id": 5,
+            "tag": 2
+        }
+    },
+    {
         "model": "extras.webhook",
         "pk": 1,
         "fields": {
@@ -6345,7 +6689,7 @@
         "pk": 1,
         "fields": {
             "created": "2021-02-21",
-            "last_updated": "2021-02-21T23:51:41.414Z",
+            "last_updated": "2021-03-08T14:49:34.835Z",
             "custom_field_data": {},
             "local_context_data": {
                 "context": "a"
@@ -6356,7 +6700,7 @@
             "name": "VM A",
             "status": "active",
             "role": 1,
-            "primary_ip4": null,
+            "primary_ip4": 3,
             "primary_ip6": null,
             "vcpus": 1,
             "memory": 1,
@@ -6369,7 +6713,7 @@
         "pk": 2,
         "fields": {
             "created": "2021-02-21",
-            "last_updated": "2021-02-21T23:52:35.437Z",
+            "last_updated": "2021-03-08T15:01:17.847Z",
             "custom_field_data": {},
             "local_context_data": null,
             "cluster": 2,
@@ -6379,7 +6723,7 @@
             "status": "active",
             "role": 2,
             "primary_ip4": null,
-            "primary_ip6": null,
+            "primary_ip6": 5,
             "vcpus": null,
             "memory": null,
             "disk": null,

--- a/nautobot_netbox_importer/tests/test_import.py
+++ b/nautobot_netbox_importer/tests/test_import.py
@@ -80,4 +80,6 @@ class TestImport(TestCase):
                     if isinstance(expected_value, list) and not isinstance(actual_value, list):
                         actual_value = list(actual_value.get_queryset())
 
-                    self.assertEqual(expected_value, actual_value, f"key {key} on {model} {record} is incorrect")
+                    self.assertEqual(
+                        expected_value, actual_value, f"key {key} on {model} {record} ({actual_value}) is incorrect"
+                    )


### PR DESCRIPTION
- Catch Django ValidationError when creating/updating Nautobot data. Fixes #4
- Catch Pydantic ValidationError when creating/updating internal data model. Fixes #5
- Add ObjectNotFound error handling for GenericForeignKey fields. Fixes #2 
- Enable importing data exported from NetBox 2.10.5. Fixes #3 
- Improve logging when errors are encountered during data loading
- Permit Devices with no name; add more fields to Device._identifiers to better distinguish device uniqueness
- Process templates *after* processing devices so that devices get initialized empty instead of pre-populated with components (since we will add the components ourselves)
- Fixed some incorrect definitions of the Service and PowerOutletTemplate models. Fixes #8.
- Populate the test data dump with additional data: Services, IPv6 addresses, and device component templates.