### PR TITLE
Import Status references symmetrically between NetBox and Nautobot

### DIFF
--- a/nautobot_netbox_importer/diffsync/adapters/nautobot.py
+++ b/nautobot_netbox_importer/diffsync/adapters/nautobot.py
@@ -55,6 +55,10 @@ class NautobotDiffSync(N2NDiffSync):
             # What's the name of the model that this is a reference to?
             target_name = diffsync_model.fk_associations()[field.name]
 
+            if target_name == "status":
+                data[field.name] = {"slug": self.status.nautobot_model().objects.get(pk=value).slug}
+                continue
+
             # Special case: for generic foreign keys, the target_name is actually the name of
             # another field on this record that describes the content-type of this foreign key id.
             # We flag this by starting the target_name string with a '*', as if this were C or something.

--- a/nautobot_netbox_importer/diffsync/models/abstract.py
+++ b/nautobot_netbox_importer/diffsync/models/abstract.py
@@ -75,9 +75,9 @@ class DjangoBaseModel(DiffSyncModel):
         """Get the mapping between foreign key (FK) fields and the corresponding DiffSync models they reference."""
         return cls._fk_associations
 
-    @staticmethod
+    @classmethod
     def _get_nautobot_record(
-        diffsync_model: DiffSyncModel, diffsync_value: Any, fail_quiet: bool = False
+        cls, diffsync_model: DiffSyncModel, diffsync_value: Any, fail_quiet: bool = False
     ) -> Optional[models.Model]:
         """Given a diffsync model and identifier (natural key or primary key) look up the Nautobot record."""
         try:
@@ -93,6 +93,7 @@ class DjangoBaseModel(DiffSyncModel):
             log = logger.debug if fail_quiet else logger.error
             log(
                 "Expected but did not find an existing Nautobot record",
+                source=cls.get_type(),
                 target=diffsync_model.get_type(),
                 unique_id=diffsync_value,
             )

--- a/nautobot_netbox_importer/tests/test_import.py
+++ b/nautobot_netbox_importer/tests/test_import.py
@@ -4,11 +4,9 @@ import os
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import call_command
 from django.test import TestCase
-from packaging import version
 import yaml
-
-from nautobot_netbox_importer.management.commands.import_netbox_json import Command
 
 
 NETBOX_DATA_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "netbox_dump.json")
@@ -21,8 +19,8 @@ class TestImport(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         """One-time setup function called before running the test functions in this class."""
-        with open(NETBOX_DATA_FILE, "r") as handle:
-            Command().handle(json_file=handle, netbox_version=version.Version("2.10.4"), verbosity=0)
+        call_command("import_netbox_json", NETBOX_DATA_FILE, "2.10.4", verbosity=0)
+        # TODO check stdout/stderr for errors and such
         with open(NAUTOBOT_DATA_FILE, "r") as handle:
             cls.nautobot_data = yaml.safe_load(handle)
 
@@ -83,7 +81,6 @@ class TestImport(TestCase):
 
     def test_resync_without_changes_correctness(self):
         """Resync (with no changes to the source data) and verify that data is still correct."""
-        with open(NETBOX_DATA_FILE, "r") as handle:
-            Command().handle(json_file=handle, netbox_version=version.Version("2.10.4"), verbosity=0)
-        # TODO check logs for errors and such
+        call_command("import_netbox_json", NETBOX_DATA_FILE, "2.10.4", verbosity=0)
+        # TODO check stdout/stderr for errors and such
         self.test_imported_data_correctness()


### PR DESCRIPTION
- Just as status values imported from the NetBox data are replaced with `{"slug": value}` natural keys, ensure that we do the same thing with Status references imported from Nautobot. Fixes #32.
- Add a bit more contextual information to the "Expected but did not find an existing Nautobot record" error message
- In test code, use `call_command()` API instead of calling `Command.handle()` so as to ensure that the correct test database is used.