### PR TITLE
Issue #47: ChangeLogged objects honour `created` date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.0 (2021-05-xx)
+
+### Fixed
+
+- #47 - `ChangeLogged` objects honour `created` date when they are imported and also a related "udpated" `ChangeObject` is created as result of the migration.
+
 ## v1.3.0 (2021-05-11)
 
 ### Added
@@ -16,7 +22,6 @@
   the `master` `Device` occupies a `vc_position` other than `1`.
 - #43 - Development and CI testing now defaults to Nautobot 1.0.0 instead of 1.0.0b3
 - #43 - Fix test approach to ensure that tests execute against the test database rather than the development database.
-- #47 - ChangeLogged objects honour `created` date and also ChangeObject to represent the migration is created
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   the `master` `Device` occupies a `vc_position` other than `1`.
 - #43 - Development and CI testing now defaults to Nautobot 1.0.0 instead of 1.0.0b3
 - #43 - Fix test approach to ensure that tests execute against the test database rather than the development database.
+- #47 - ChangeLogged objects honour `created` date and also ChangeObject to represent the migration is created
 
 ### Changed
 
@@ -42,7 +43,6 @@
 - #31 - Records containing outdated custom field data should now be updated successfully
 - #32 - Status objects should not show as changed when resyncing data
 
-
 ## v1.1.0 (2021-04-07)
 
 ### Added
@@ -67,7 +67,6 @@
 
 - No longer compatible with Nautobot 1.0.0b2 and earlier
 
-
 ## v1.0.1 (2021-03-09)
 
 ### Added
@@ -85,10 +84,9 @@
 - #4 - Django `ValidationError` is now caught when creating/updating Nautobot data
 - #5 - Pydantic `ValidationError` is now caught when constructing internal data models
 - `Device`s with no specified `name` can now be imported successfully.
-- Device component templates are now imported *after* `Device`s so as to avoid encountering errors when components are unexpectedly created from the templates.
+- Device component templates are now imported _after_ `Device`s so as to avoid encountering errors when components are unexpectedly created from the templates.
 - `VRF`s with no specified `rd` can now be imported successfully.
 - #8 - Fixed errors in `Service` and `PowerOutletTemplate` model definitions that prevented them from being imported.
-
 
 ## v1.0.0 (2021-02-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- #47 - `ChangeLogged` objects honour `created` date when they are imported and also a related "udpated" `ChangeObject` is created as result of the migration.
+- #47 - `ChangeLogged` objects honour `created` date when they are imported and also a related "updated" `ObjectChange` is created as result of the migration.
 
 ## v1.3.0 (2021-05-11)
 

--- a/nautobot_netbox_importer/diffsync/models/abstract.py
+++ b/nautobot_netbox_importer/diffsync/models/abstract.py
@@ -57,6 +57,9 @@ class DjangoBaseModel(DiffSyncModel):
         {"site": "site", "parent": "rackgroup"}
     """
 
+    _importer_request_id: uuid.UUID = uuid.uuid4()
+    """Consistent Request_id used across the whole import when creating ObjectChanges for ChangeLoggedModel objects."""
+
     pk: Union[uuid.UUID, int]
 
     @classmethod
@@ -187,8 +190,8 @@ class DjangoBaseModel(DiffSyncModel):
         """Translate any DiffSync "attrs" fields to the corresponding Nautobot data model fields."""
         return cls.clean_ids_or_attrs(diffsync, attrs)
 
-    @staticmethod
-    def create_nautobot_record(nautobot_model, ids: Mapping, attrs: Mapping, multivalue_attrs: Mapping):
+    @classmethod
+    def create_nautobot_record(cls, nautobot_model, ids: Mapping, attrs: Mapping, multivalue_attrs: Mapping):
         """Helper method to create() - actually populate Nautobot data."""
         model_data = dict(**ids, **attrs, **multivalue_attrs)
         try:
@@ -213,8 +216,7 @@ class DjangoBaseModel(DiffSyncModel):
                     object_repr=str(record),
                     action="update",
                     object_data=serialize_object(record),
-                    # # Random request_id as it's mandatory
-                    request_id=uuid.uuid4(),
+                    request_id=cls._importer_request_id,
                 )
 
             for attr, value in multivalue_attrs.items():

--- a/nautobot_netbox_importer/diffsync/models/abstract.py
+++ b/nautobot_netbox_importer/diffsync/models/abstract.py
@@ -439,7 +439,6 @@ class CableTerminationMixin(BaseModel):
 class ChangeLoggedModelMixin(BaseModel):
     """An abstract model which adds fields to store the creation and last-updated times for an object."""
 
-    # created is set automatically on model creation, so don't try to sync it between systems
     # last_updated is updated automatically on model create/update, so don't try to sync it between systems
     _attributes = ("created",)
 

--- a/nautobot_netbox_importer/diffsync/models/extras.py
+++ b/nautobot_netbox_importer/diffsync/models/extras.py
@@ -46,6 +46,7 @@ class ConfigContext(ChangeLoggedModelMixin, NautobotBaseModel):
 
     _modelname = "configcontext"
     _attributes = (
+        *ChangeLoggedModelMixin._attributes,
         "name",
         "weight",
         "description",
@@ -157,7 +158,17 @@ class CustomLink(ChangeLoggedModelMixin, NautobotBaseModel):
     """A custom link to an external representation of a Nautobot object."""
 
     _modelname = "customlink"
-    _attributes = ("name", "content_type", "text", "target_url", "weight", "group_name", "button_class", "new_window")
+    _attributes = (
+        "name",
+        "content_type",
+        "text",
+        "target_url",
+        "weight",
+        "group_name",
+        "button_class",
+        "new_window",
+        *ChangeLoggedModelMixin._attributes,
+    )
     _nautobot_model = extras.CustomLink
 
     name: str
@@ -182,7 +193,15 @@ class ExportTemplate(ChangeLoggedModelMixin, NautobotBaseModel):
     """A Jinja2 template for exporting records as text."""
 
     _modelname = "exporttemplate"
-    _attributes = ("name", "content_type", "description", "template_code", "mime_type", "file_extension")
+    _attributes = (
+        "name",
+        "content_type",
+        "description",
+        "template_code",
+        "mime_type",
+        "file_extension",
+        *ChangeLoggedModelMixin._attributes,
+    )
     _nautobot_model = extras.ExportTemplate
 
     name: str
@@ -282,7 +301,7 @@ class Status(ChangeLoggedModelMixin, NautobotBaseModel):
     """Representation of a status value."""
 
     _modelname = "status"
-    _attributes = ("slug", "name", "color", "description")  # TODO content_types?
+    _attributes = ("slug", "name", "color", "description", *ChangeLoggedModelMixin._attributes)  # TODO content_types?
     _nautobot_model = extras.Status
 
     slug: str
@@ -297,7 +316,14 @@ class Tag(ChangeLoggedModelMixin, CustomFieldModelMixin, NautobotBaseModel):
     """A tag that can be associated with various objects."""
 
     _modelname = "tag"
-    _attributes = (*CustomFieldModelMixin._attributes, "name", "slug", "color", "description")
+    _attributes = (
+        *CustomFieldModelMixin._attributes,
+        "name",
+        "slug",
+        "color",
+        "description",
+        *ChangeLoggedModelMixin._attributes,
+    )
     _nautobot_model = extras.Tag
 
     name: str
@@ -339,6 +365,7 @@ class Webhook(ChangeLoggedModelMixin, NautobotBaseModel):
         "secret",
         "ssl_verification",
         "ca_file_path",
+        *ChangeLoggedModelMixin._attributes,
     )
     _nautobot_model = extras.Webhook
 

--- a/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
+++ b/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
@@ -4243,6 +4243,7 @@
   ids:
     name: Site A
   fields:
+    created: '2021-02-21'
     asn: null
     comments: ''
     contact_email: ''

--- a/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
+++ b/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
@@ -2534,6 +2534,7 @@
   ids:
     name: Provider A
   fields:
+    created: '2021-02-21'
     account: A
     admin_contact: A
     asn: 11111
@@ -2546,6 +2547,7 @@
   ids:
     name: Provider B
   fields:
+    created: '2021-02-21'
     account: ''
     admin_contact: ''
     asn: 2222
@@ -2558,12 +2560,14 @@
   ids:
     name: Circuit Type A
   fields:
+    created: '2021-02-21'
     description: A
     slug: circuit-type-a
 - model: circuits.circuittype
   ids:
     name: Circuit Type B
   fields:
+    created: '2021-02-21'
     description: ''
     slug: circuit-type-b
 - model: circuits.circuit
@@ -2573,6 +2577,7 @@
         name: Provider A
     cid: Circuit A
   fields:
+    created: '2021-02-21'
     comments: A
     commit_rate: 1
     custom_field_data: {}
@@ -2594,6 +2599,7 @@
         name: Provider B
     cid: Circuit B
   fields:
+    created: '2021-02-21'
     comments: ''
     commit_rate: null
     custom_field_data: {}
@@ -3367,18 +3373,21 @@
   ids:
     name: Manufacturer A
   fields:
+    created: '2021-02-21'
     description: ''
     slug: manufacturer-a
 - model: dcim.manufacturer
   ids:
     name: Manufacturer B
   fields:
+    created: '2021-02-21'
     description: ''
     slug: manufacturer-b
 - model: dcim.devicetype
   ids:
     model: Model A
   fields:
+    created: '2021-02-21'
     comments: ''
     custom_field_data: {}
     front_image: "devicetype-images/nautobot_logo.png"
@@ -3395,6 +3404,7 @@
   ids:
     model: Model A Child
   fields:
+    created: '2021-02-21'
     comments: ''
     custom_field_data: {}
     front_image: ''
@@ -3411,6 +3421,7 @@
   ids:
     model: Model B
   fields:
+    created: '2021-02-21'
     comments: ''
     custom_field_data: {}
     front_image: ''
@@ -3427,6 +3438,7 @@
   ids:
     name: Device Role A
   fields:
+    created: '2021-02-21'
     color: f44336
     description: ''
     slug: device-role-a
@@ -3435,6 +3447,7 @@
   ids:
     name: Device Role B
   fields:
+    created: '2021-02-21'
     color: 4caf50
     description: B
     slug: device-role-b
@@ -3443,6 +3456,7 @@
   ids:
     name: Platform A
   fields:
+    created: '2021-02-21'
     description: ''
     manufacturer:
       ids:
@@ -3454,6 +3468,7 @@
   ids:
     name: Platform B
   fields:
+    created: '2021-02-21'
     description: b
     manufacturer:
       ids:
@@ -3466,6 +3481,7 @@
   ids:
     name: "Device A Parent"
   fields:
+    created: '2021-02-21'
     asset_tag: null
     cluster:
       ids:
@@ -3509,6 +3525,7 @@
   ids:
     name: "Device A Child"
   fields:
+    created: '2021-02-21'
     asset_tag: null
     cluster:
       ids:
@@ -3551,6 +3568,7 @@
   ids:
     name: "Device B"
   fields:
+    created: '2021-02-21'
     asset_tag: null
     cluster:
       ids:
@@ -3591,6 +3609,7 @@
   ids:
     name: "VC A Master"
   fields:
+    created: '2021-04-29'
     asset_tag: null
     cluster: null
     comments: ""
@@ -3627,6 +3646,7 @@
   ids:
     name: "VC A Member 1"
   fields:
+    created: '2021-04-29'
     asset_tag: null
     cluster: null
     comments: ""
@@ -3663,6 +3683,7 @@
   ids:
     name: "VC A Member 2"
   fields:
+    created: '2021-04-29'
     asset_tag: null
     cluster: null
     comments: ""
@@ -3699,6 +3720,7 @@
   ids:
     name: Virtual Chassis A
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     domain: ''
     master:
@@ -3708,6 +3730,7 @@
   ids:
     name: Virtual Chassis B
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     domain: ''
     master: null
@@ -3715,6 +3738,7 @@
 # - model: dcim.cable
 #   ids: null
 #   fields:
+#     created: '2021-02-21'
 #     color: '795548'
 #     custom_field_data: {}
 #     label: ''
@@ -4300,6 +4324,7 @@
   ids:
     name: VRF A
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     enforce_unique: true
@@ -4317,6 +4342,7 @@
   ids:
     name: VRF B
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     enforce_unique: true
@@ -4334,6 +4360,7 @@
   ids:
     name: Route Target A
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     tenant:
@@ -4343,6 +4370,7 @@
   ids:
     name: Route Target B
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     tenant:
@@ -4352,6 +4380,7 @@
   ids:
     name: RIR A
   fields:
+    created: '2021-02-21'
     description: ''
     is_private: false
     slug: rir-a
@@ -4359,6 +4388,7 @@
   ids:
     name: RIR B
   fields:
+    created: '2021-02-21'
     description: ''
     is_private: false
     slug: rir-b
@@ -4366,6 +4396,7 @@
   ids:
     prefix: 10.0.0.0/8
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     date_added: '2021-02-21'
     description: ''
@@ -4379,6 +4410,7 @@
   ids:
     prefix: 172.16.0.0/16
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     date_added: null
     description: ''
@@ -4392,6 +4424,7 @@
   ids:
     prefix: "fe80::/10"
   fields:
+    created: '2021-03-08'
     custom_field_data: {}
     date_added: "2021-03-08"
     description: "Link-local addresses"
@@ -4403,6 +4436,7 @@
   ids:
     prefix: "2001:db8::/32"
   fields:
+    created: '2021-03-08'
     custom_field_data: {}
     date_added: "2021-03-08"
     description: ""
@@ -4414,6 +4448,7 @@
   ids:
     name: Role A
   fields:
+    created: '2021-02-21'
     description: ''
     slug: role-a
     weight: 1000
@@ -4421,6 +4456,7 @@
   ids:
     name: Role B
   fields:
+    created: '2021-02-21'
     description: ''
     slug: role-b
     weight: 1000
@@ -4428,6 +4464,7 @@
   ids:
     prefix: 10.1.0.0/16
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     is_pool: false
@@ -4453,6 +4490,7 @@
   ids:
     prefix: 10.1.1.0/24
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     is_pool: false
@@ -4472,6 +4510,7 @@
   ids:
     prefix: 172.16.1.0/24
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     is_pool: false
@@ -4497,6 +4536,7 @@
   ids:
     prefix: "fe80::/64"
   fields:
+    created: '2021-03-08'
     custom_field_data: {}
     description: ""
     is_pool: false
@@ -4512,6 +4552,7 @@
   ids:
     prefix: "2001:db8:0:1::/64"
   fields:
+    created: '2021-03-08'
     custom_field_data: {}
     description: ""
     is_pool: false
@@ -4537,6 +4578,7 @@
   ids:
     address: 10.1.1.1/32
   fields:
+    created: '2021-02-21'
     # TODO assigned_object_id: 2
     assigned_object_type:
       ids:
@@ -4560,6 +4602,7 @@
   ids:
     address: 10.1.1.2/32
   fields:
+    created: '2021-02-21'
     # TODO assigned_object_id: 1
     assigned_object_type:
       ids:
@@ -4585,6 +4628,7 @@
   ids:
     address: 10.1.1.3/24
   fields:
+    created: '2021-03-08'
     # TODO assigned_object_id
     assigned_object_type:
       ids:
@@ -4604,6 +4648,7 @@
   ids:
     address: "fe80::1c46:231c:ce55:25dd/128"
   fields:
+    created: '2021-03-08'
     # TODO assigned_object_id
     assigned_object_type:
       ids:
@@ -4627,6 +4672,7 @@
   ids:
     address: "2001:db8:0:1:1::1/80"
   fields:
+    created: '2021-03-08'
     # TODO assigned_object_id
     assigned_object_type:
       ids:
@@ -4650,6 +4696,7 @@
   ids:
     address: "2001:db8:0:1::1/64"
   fields:
+    created: '2021-03-08'
     assigned_object_id: null
     assigned_object_type: null
     custom_field_data: {}
@@ -4670,6 +4717,7 @@
   ids:
     name: VLAN Group A
   fields:
+    created: '2021-02-21'
     description: ''
     site:
       ids:
@@ -4679,6 +4727,7 @@
   ids:
     name: VLAN Group B
   fields:
+    created: '2021-02-21'
     description: ''
     site:
       ids:
@@ -4688,6 +4737,7 @@
   ids:
     name: VLAN A
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     group:
@@ -4710,6 +4760,7 @@
   ids:
     name: VLAN B
   fields:
+    created: '2021-02-21'
     custom_field_data: {}
     description: ''
     group:
@@ -4732,6 +4783,7 @@
   ids:
     name: "Service A"
   fields:
+    created: '2021-03-08'
     custom_field_data: {}
     description: "Service A on VM A"
     device: null
@@ -4747,6 +4799,7 @@
   ids:
     name: "Service B"
   fields:
+    created: '2021-03-08'
     custom_field_data: {}
     description: ""
     device: null
@@ -4846,6 +4899,7 @@
   ids:
     name: Tag A
   fields:
+    created: '2021-02-21'
     color: f44336
     description: ''
     slug: tag-a
@@ -4853,6 +4907,7 @@
   ids:
     name: Tag B
   fields:
+    created: '2021-02-21'
     color: 4caf50
     description: ''
     slug: tag-b
@@ -5645,6 +5700,7 @@
   ids:
     name: Config Context A
   fields:
+    created: '2021-02-22'
     cluster_groups:
     - ids:
         name: "Cluster Group A"
@@ -5681,6 +5737,7 @@
   ids:
     name: Config Context B
   fields:
+    created: '2021-02-22'
     cluster_groups:
     - ids:
         name: "Cluster Group B"
@@ -5717,6 +5774,7 @@
   ids:
     name: Parent Tenant Group
   fields:
+    created: '2021-02-21'
     description: The parent tenant group
     parent: null
     slug: parent-tenant-group
@@ -5724,6 +5782,7 @@
   ids:
     name: Child Tenant Group
   fields:
+    created: '2021-02-21'
     description: The child tenant group
     parent:
       ids:
@@ -5733,6 +5792,7 @@
   ids:
     name: Tenant A
   fields:
+    created: '2021-02-21'
     comments: ''
     custom_field_data: {}
     description: ''
@@ -5744,6 +5804,7 @@
   ids:
     name: Tenant B
   fields:
+    created: '2021-02-21'
     comments: ''
     custom_field_data: {}
     description: ''
@@ -5808,30 +5869,35 @@
   ids:
     name: Cluster Type A
   fields:
+    created: '2021-02-21'
     description: ''
     slug: cluster-type-a
 - model: virtualization.clustertype
   ids:
     name: Cluster Type B
   fields:
+    created: '2021-02-21'
     description: ''
     slug: cluster-type-b
 - model: virtualization.clustergroup
   ids:
     name: Cluster Group A
   fields:
+    created: '2021-02-21'
     description: ''
     slug: cluster-group-a
 - model: virtualization.clustergroup
   ids:
     name: Cluster Group B
   fields:
+    created: '2021-02-21'
     description: ''
     slug: cluster-group-b
 - model: virtualization.cluster
   ids:
     name: Cluster A
   fields:
+    created: '2021-02-21'
     comments: ''
     custom_field_data: {}
     group:
@@ -5850,6 +5916,7 @@
   ids:
     name: Cluster B
   fields:
+    created: '2021-02-21'
     comments: ''
     custom_field_data: {}
     group:
@@ -5868,6 +5935,7 @@
   ids:
     name: VM A
   fields:
+    created: '2021-02-21'
     cluster:
       ids:
         name: "Cluster A"
@@ -5898,6 +5966,7 @@
   ids:
     name: VM B
   fields:
+    created: '2021-02-21'
     cluster:
       ids:
         name: "Cluster B"

--- a/nautobot_netbox_importer/tests/test_import.py
+++ b/nautobot_netbox_importer/tests/test_import.py
@@ -78,10 +78,9 @@ class TestImport(TestCase):
                 # Validate that the ChangeLogged objects have a related ObjectChange
                 if (
                     issubclass(type(record), ChangeLoggedModel)
-                    and ObjectChange.objects.filter(
+                    and not ObjectChange.objects.filter(
                         changed_object_type=content_type, changed_object_id=record.pk
-                    ).count()
-                    == 0
+                    ).exists()
                 ):
                     self.fail(f"Record {model_class} {data['ids']} has not a related ObjectChange")
 

--- a/nautobot_netbox_importer/tests/test_import.py
+++ b/nautobot_netbox_importer/tests/test_import.py
@@ -8,6 +8,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 import yaml
 
+from nautobot.extras.models import ObjectChange, ChangeLoggedModel
+
 from nautobot_netbox_importer.management.commands.import_netbox_json import Command
 
 
@@ -72,6 +74,17 @@ class TestImport(TestCase):
                     record = model_class.objects.get(**self.fixup_refs(model_class, data["ids"]))
                 except ObjectDoesNotExist:
                     self.fail(f"Record {model_class} {data['ids']} missing in Nautobot")
+
+                # Validate that the ChangeLogged objects have a related ObjectChange
+                if (
+                    issubclass(type(record), ChangeLoggedModel)
+                    and ObjectChange.objects.filter(
+                        changed_object_type=content_type, changed_object_id=record.pk
+                    ).count()
+                    == 0
+                ):
+                    self.fail(f"Record {model_class} {data['ids']} has not a related ObjectChange")
+
                 for key, expected_value in self.fixup_refs(model_class, data.get("fields", {})).items():
                     actual_value = getattr(record, key)
                     if isinstance(expected_value, str):


### PR DESCRIPTION


- [x] Define a test that validates that the `created` date is honoured and a ObjectChange for the migration update exists
- [x] Implement the fix
- [x] Extend the `nautbot_expectation.yaml` to add the proper `created` date

Addresses issue #47 

![Screenshot 2021-05-21 at 10 12 13](https://user-images.githubusercontent.com/15998111/119113847-cf55e000-ba25-11eb-9cf5-2740736396f2.png)