### PR TITLE
Fix potential error when importing JobResult records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 1.4.0 (2021-05-xx)
+## 1.4.0 (2021-xx-xx)
 
 ### Fixed
 
 - #47 - `ChangeLogged` objects honour `created` date when they are imported and also a related "updated" `ObjectChange` is created as result of the migration.
+- #51 - Potential `KeyError` when importing certain `JobResult` records.
 
 ## v1.3.0 (2021-05-11)
 

--- a/nautobot_netbox_importer/diffsync/models/extras.py
+++ b/nautobot_netbox_importer/diffsync/models/extras.py
@@ -255,8 +255,10 @@ class JobResultData(DiffSyncCustomValidationField, dict):
                 }
                 for log_entry in value.get("log", []):
                     new_value["run"]["log"].append((None, log_entry["status"], None, None, log_entry["message"]))
-                    new_value["run"][log_entry["status"]] += 1
-                    new_value["total"][log_entry["status"]] += 1
+                    if log_entry["status"] in new_value["run"]:
+                        new_value["run"][log_entry["status"]] += 1
+                    if log_entry["status"] in new_value["total"]:
+                        new_value["total"][log_entry["status"]] += 1
                 value = new_value
             else:
                 # Either a Nautobot record (in which case no reformatting needed) or a NetBox Report result

--- a/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
+++ b/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
@@ -5770,6 +5770,64 @@
     - ids:
         name: "Tenant B"
     weight: 1000
+- model: extras.jobresult
+  ids:
+    job_id: "0de2b9a3-a54f-493e-8cba-50f1ab66f425"
+  fields:
+    name: "netbb.NetBB"
+    obj_type:
+      ids:
+        app_label: "extras"
+        model: "job"
+    completed: "2020-08-11 08:38:40.096000+00:00"
+    user: null
+    status: "completed"
+    data:
+      test_devices:
+        log:
+          - ["2020-08-11T08:38:39.814811+00:00", "warning", "node001-bm092", "/dcim/devices/100/", "Asset Tag missing"]
+          - ["2020-08-11T08:38:39.833042+00:00", "warning", "node002-bm092", "/dcim/devices/200/", "Asset Tag missing"]
+        info: 0
+        failure: 0
+        success: 0
+        warning: 2
+      total:
+        info: 0
+        failure: 0
+        success: 0
+        warning: 2
+      output: ""
+- model: extras.jobresult
+  ids:
+    job_id: "00cd96ba-b4c2-4323-919e-ceb021c28537"
+  fields:
+    name: "blueprint-tools.RackExcelExporter"
+    obj_type:
+      ids:
+        app_label: "extras"
+        model: "job"
+    completed: "2021-05-10 03:30:19.244000+00:00"
+    user:
+      ids:
+        username: "admin"
+    status: "completed"
+    data:
+      run:
+        log:
+          - [null, "default", null, null, "default log message"]
+          - [null, "info", null, null, "info log message"]
+          - [null, "success", null, null, "Exporting racks\nNetbox export finished \n\n"]
+          - [null, "success", null, null, "Completed!"]
+        success: 2
+        info: 1
+        warning: 0
+        failure: 0
+      total:
+        success: 2
+        info: 1
+        warning: 0
+        failure: 0
+      output: "Debug Output:\nExporting racks\nNetbox export finished \n\n\n/opt/netbox/venv/bin/python3 /opt/netbox-blueprinter/netbox-cabling.py \nCompletedProcess(args=['/opt/netbox/venv/bin/python3', '/opt/netbox-blueprinter/netbox-cabling.py'], returncode=0, stdout=b'Exporting racks\\nNetbox export finished \\n\\n', stderr=b'')"
 - model: tenancy.tenantgroup
   ids:
     name: Parent Tenant Group

--- a/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
+++ b/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
@@ -7174,6 +7174,77 @@
         }
     },
     {
+        "model": "extras.jobresult",
+        "pk": 252,
+        "fields": {
+            "name": "netbb.NetBB",
+            "obj_type": 12,
+            "created": "2020-10-08T07:18:22.151Z",
+            "completed": "2020-08-11T08:38:40.096Z",
+            "user": null,
+            "status": "completed",
+            "data": {
+                "test_devices": {
+                    "log": [
+                        [
+                            "2020-08-11T08:38:39.814811+00:00",
+                            "warning",
+                            "node001-bm092",
+                            "/dcim/devices/100/",
+                            "Asset Tag missing"
+                        ],
+                        [
+                            "2020-08-11T08:38:39.833042+00:00",
+                            "warning",
+                            "node002-bm092",
+                            "/dcim/devices/200/",
+                            "Asset Tag missing"
+                        ]
+                    ],
+                    "info": 0,
+                    "failure": 0,
+                    "success": 0,
+                    "warning": 2
+                }
+            },
+            "job_id": "0de2b9a3-a54f-493e-8cba-50f1ab66f425"
+        }
+    },
+    {
+        "model": "extras.jobresult",
+        "pk": 782,
+        "fields": {
+            "name": "blueprint-tools.RackExcelExporter",
+            "obj_type": 68,
+            "created": "2021-05-10T03:30:17.737Z",
+            "completed": "2021-05-10T03:30:19.244Z",
+            "user": 1,
+            "status": "completed",
+            "data": {
+                "log": [
+                    {
+                        "status": "default",
+                        "message": "default log message"
+                    },
+                    {
+                        "status": "info",
+                        "message": "info log message"
+                    },
+                    {
+                        "status": "success",
+                        "message": "Exporting racks\nNetbox export finished \n\n"
+                    },
+                    {
+                        "status": "success",
+                        "message": "Completed!"
+                    }
+                ],
+                "output": "Debug Output:\nExporting racks\nNetbox export finished \n\n\n/opt/netbox/venv/bin/python3 /opt/netbox-blueprinter/netbox-cabling.py \nCompletedProcess(args=['/opt/netbox/venv/bin/python3', '/opt/netbox-blueprinter/netbox-cabling.py'], returncode=0, stdout=b'Exporting racks\\nNetbox export finished \\n\\n', stderr=b'')"
+            },
+            "job_id": "00cd96ba-b4c2-4323-919e-ceb021c28537"
+        }
+    },
+    {
         "model": "tenancy.tenantgroup",
         "pk": 1,
         "fields": {

--- a/nautobot_netbox_importer/tests/test_import.py
+++ b/nautobot_netbox_importer/tests/test_import.py
@@ -20,6 +20,8 @@ NAUTOBOT_DATA_FILE = os.path.join(os.path.dirname(__file__), "fixtures", "nautob
 class TestImport(TestCase):
     """Test the importing functionality of nautobot-netbox-importer."""
 
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls) -> None:
         """One-time setup function called before running the test functions in this class."""


### PR DESCRIPTION
Fixing a user-reported issue where a `KeyError` exception could be thrown while importing JobResult records containing certain types of log entries.

Added example JobResult test fixtures, including a Script result that would trigger this error and a Report result as well.