### PR TITLE
Add --bypass-data-validation optional flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.4.0 (2021-xx-xx)
 
+### Added
+
+- #52 - Added `--bypass-data-validation` optional flag on import for users who absolutely need to be able to import data from NetBox that will fail Nautobot's data validation checks.
+
 ### Fixed
 
 - #47 - `ChangeLogged` objects honour `created` date when they are imported and also a related "updated" `ObjectChange` is created as result of the migration.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ PLUGINS = ["nautobot_netbox_importer"]
 
 ## Usage
 
-### Getting a data export from NetBox
+This plugin provides two separate commands, one for importing data records into Nautobot and one for importing the database changelog into Nautobot as an optional secondary step.
+
+### Importing data records into Nautobot
+
+#### Getting a data export from NetBox
 
 From the NetBox root directory, run the following command to produce a JSON file (here, `/tmp/netbox_data.json`) describing the contents of your NetBox database:
 
@@ -32,9 +36,48 @@ python netbox/manage.py dumpdata \
     > /tmp/netbox_data.json
 ```
 
-### Importing the data into Nautobot
+#### Importing the data into Nautobot
 
 From within the Nautobot application environment, run `nautobot-server import_netbox_json <json_file> <netbox_version>`, for example `nautobot-server import_netbox_json /tmp/netbox_data.json 2.10.3`.
+
+#### Data validation and error handling
+
+Note that the importer *does* apply Nautobot's data validation standards to the data records as it imports them. If any data records fail data validation, you will see detailed error messages. For example, the following error might be generated if your NetBox data somehow contains a Rack that is assigned to Site-1 but belongs to a RackGroup located at Site-2:
+
+```
+09:42:43 error    Nautobot reported a data validation error - check your source data
+  action: create
+  exception: ['Assigned rack group must belong to parent site (Site-1).']
+  model: <class 'nautobot.dcim.models.racks.Rack'>
+  model_data:
+    {'asset_tag': None,
+     'comments': '',
+     'custom_field_data': {},
+     'desc_units': False,
+     'facility_id': ''
+     'group': <RackGroup: Cage2>,
+     'name': 'Rack-1',
+     'outer_depth': None,
+     'outer_unit': '',
+     'outer_width': None,
+     'pk': UUID('25b61428-813b-5d42-b7ea-38cd541c925a'),
+     'role': <RackRole: vPOD>,
+     'serial': '',
+     'site': <Site: Site-1>,
+     'status': <Status: Active>,
+     'tenant': None,
+     'type': '4-post-cabinet',
+     'u_height': 42,
+     'width': 19}
+```
+
+In this case, the import of this Rack into Nautobot will fail, and you may see a series of cascading errors as other objects dependent on this Rack (such as Devices) also fail due to the absence of this Rack.
+
+Normally the correct response to this sort of error is to understand the cause of the error, log into your NetBox instance and correct the invalid data, then re-export the data from NetBox and re-run the importer.
+
+**If**, however, fixing the source data in NetBox is not possible for whatever reason, you **can** instruct the importer to import data *even if it fails Nautobot's data validation checks*, by specifying the option `--bypass-data-validation`. This **will** result in your Nautobot database containing invalid data, which you will want to fix up in Nautobot as soon as possible to avoid unexpected errors in the future.
+
+When using the `--bypass-data-validation` option, data validation checks are still run, but any failures will be logged as warnings (rather than errors), so that you can still be aware of any issues that will need to be remediated in Nautobot.
 
 ### Importing change logging (ObjectChange) records
 

--- a/nautobot_netbox_importer/diffsync/adapters/nautobot.py
+++ b/nautobot_netbox_importer/diffsync/adapters/nautobot.py
@@ -26,6 +26,11 @@ class NautobotDiffSync(N2NDiffSync):
 
     logger = structlog.get_logger()
 
+    def __init__(self, *args, bypass_data_validation=False, **kwargs):
+        """Initialization of a NautobotDiffSync adapater instance."""
+        super().__init__(*args, **kwargs)
+        self.bypass_data_validation = bypass_data_validation
+
     def load_model(self, diffsync_model, record):  # pylint: disable=too-many-branches
         """Instantiate the given DiffSync model class from the given Django record."""
         data = {}

--- a/nautobot_netbox_importer/management/commands/import_netbox_json.py
+++ b/nautobot_netbox_importer/management/commands/import_netbox_json.py
@@ -21,6 +21,14 @@ class Command(BaseCommand):
         """Add parser arguments to the import_netbox_json management command."""
         parser.add_argument("json_file", type=argparse.FileType("r"))
         parser.add_argument("netbox_version", type=version.parse)
+        parser.add_argument(
+            "--bypass-data-validation",
+            action="store_true",
+            help="Bypass as much of Nautobot's internal data validation logic as possible, allowing the import of "
+            "data from NetBox that would be rejected as invalid if entered as-is through the GUI or REST API. "
+            "USE WITH CAUTION: it is generally more desirable to *take note* of any data validation errors, "
+            "*correct* the invalid data in NetBox, and *re-import* with the corrected data! ",
+        )
 
     def handle(self, *args, **options):
         """Handle execution of the import_netbox_json management command."""
@@ -38,7 +46,9 @@ class Command(BaseCommand):
         source = netbox_adapters[options["netbox_version"]](source_data=data, verbosity=options["verbosity"])
         source.load()
 
-        target = NautobotDiffSync(verbosity=options["verbosity"])
+        target = NautobotDiffSync(
+            verbosity=options["verbosity"], bypass_data_validation=options["bypass_data_validation"]
+        )
         target.load()
 
         # Lower the verbosity of newly created structlog loggers by one (half-) step

--- a/nautobot_netbox_importer/tests/fixtures/netbox_dump_invalid_rack.json
+++ b/nautobot_netbox_importer/tests/fixtures/netbox_dump_invalid_rack.json
@@ -1,0 +1,108 @@
+[
+    {
+        "model": "dcim.region",
+        "pk": 8,
+        "fields": {
+            "created": "2018-08-06",
+            "last_updated": "2018-08-06T19:33:13.299Z",
+            "parent": null,
+            "name": "Region 1",
+            "slug": "region-1",
+            "description": ""
+        }
+    },
+    {
+        "model": "dcim.site",
+        "pk": 7,
+        "fields": {
+            "created": "2016-09-05",
+            "last_updated": "2020-06-19T11:10:22.796Z",
+            "custom_field_data": {},
+            "name": "Rack Group Site",
+            "_name": "Rack Group Site",
+            "slug": "rack-group-site",
+            "status": "active",
+            "region": 8,
+            "tenant": null,
+            "facility": "Toronto 1",
+            "asn": 4294967295,
+            "time_zone": "America/Toronto",
+            "description": "",
+            "physical_address": "",
+            "shipping_address": "",
+            "latitude": null,
+            "longitude": null,
+            "contact_name": "",
+            "contact_phone": "",
+            "contact_email": "",
+            "comments": ""
+        }
+    },
+    {
+        "model": "dcim.site",
+        "pk": 8,
+        "fields": {
+            "created": "2016-09-05",
+            "last_updated": "2020-06-19T11:11:16.501Z",
+            "custom_field_data": {},
+            "name": "Rack Site",
+            "_name": "Rack Site",
+            "slug": "rack-site",
+            "status": "active",
+            "region": 8,
+            "tenant": null,
+            "facility": "Toronto 2",
+            "asn": 4294967295,
+            "time_zone": "America/Toronto",
+            "description": "",
+            "physical_address": "",
+            "shipping_address": "",
+            "latitude": null,
+            "longitude": null,
+            "contact_name": "",
+            "contact_phone": "",
+            "contact_email": "",
+            "comments": ""
+        }
+    },
+    {
+        "model": "dcim.rackgroup",
+        "pk": 14,
+        "fields": {
+            "created": "2018-08-06",
+            "last_updated": "2020-04-14T09:56:08.908Z",
+            "name": "Cage2",
+            "slug": "cage-2",
+            "site": 7,
+            "parent": null,
+            "description": ""
+        }
+    },
+    {
+        "model": "dcim.rack",
+        "pk": 86,
+        "fields": {
+            "created": "2017-07-04",
+            "last_updated": "2017-07-04T12:40:05.759Z",
+            "custom_field_data": {},
+            "name": "invalid-site-group-site-mismatch",
+            "_name": "invalid-site-group-site-mismatch",
+            "facility_id": "foo",
+            "site": 8,
+            "group": 14,
+            "tenant": null,
+            "status": "active",
+            "role": null,
+            "serial": "",
+            "asset_tag": null,
+            "type": "4-post-cabinet",
+            "width": 19,
+            "u_height": 42,
+            "desc_units": false,
+            "outer_width": null,
+            "outer_depth": null,
+            "outer_unit": "",
+            "comments": ""
+        }
+    }
+]

--- a/nautobot_netbox_importer/tests/test_import_objectchange.py
+++ b/nautobot_netbox_importer/tests/test_import_objectchange.py
@@ -56,7 +56,12 @@ class TestImportObjectChangeMethods(TestCase):
         cls.cmd.logger = Mock()
         cls.cmd.logger.warning = Mock()
         with open(NETBOX_DATA_FILE, "r") as handle:
-            Command().handle(json_file=handle, netbox_version=version.parse("2.10.4"), verbosity=0)
+            Command().handle(
+                json_file=handle,
+                netbox_version=version.parse("2.10.4"),
+                verbosity=0,
+                bypass_data_validation=False,
+            )
 
             # Create ContentType Mappings
             cls.cmd.netbox_contenttype_mapping = {}


### PR DESCRIPTION
Fixes #52.

This PR adds an optional flag to the `import_netbox_json` command, `--bypass-data-validation`. If this flag is specified, any `ValidationError`s raised by a Nautobot model's `clean()` method will be converted to warnings and the model will still be saved to the Nautobot database even though `clean()` failed.

This is added (with some misgivings) to support cases where, for whatever technical or political reason, it is not possible to correct invalid data in the source NetBox instance, and instead it is preferred to import the invalid data into Nautobot "as-is" and fix it up (or not) later within Nautobot itself.