### PR TITLE
Fix Virtual Machine Import, ensure that the vCPU Attribute is an integer

### DIFF
--- a/nautobot_netbox_importer/diffsync/adapters/netbox.py
+++ b/nautobot_netbox_importer/diffsync/adapters/netbox.py
@@ -127,6 +127,11 @@ class NetBox210DiffSync(N2NDiffSync):
                         },
                     )
                 del data["choices"]
+        elif diffsync_model == self.virtualmachine:
+            # NetBox stores the vCPU value as DecimalField, Nautobot has PositiveSmallIntegerField, 
+            # so we need to cast here
+            if data['vcpus'] is not None:
+                data['vcpus'] = int(float(data['vcpus']))
 
         return self.make_model(diffsync_model, data)
 

--- a/nautobot_netbox_importer/diffsync/adapters/netbox.py
+++ b/nautobot_netbox_importer/diffsync/adapters/netbox.py
@@ -128,10 +128,10 @@ class NetBox210DiffSync(N2NDiffSync):
                     )
                 del data["choices"]
         elif diffsync_model == self.virtualmachine:
-            # NetBox stores the vCPU value as DecimalField, Nautobot has PositiveSmallIntegerField, 
+            # NetBox stores the vCPU value as DecimalField, Nautobot has PositiveSmallIntegerField,
             # so we need to cast here
-            if data['vcpus'] is not None:
-                data['vcpus'] = int(float(data['vcpus']))
+            if data["vcpus"] is not None:
+                data["vcpus"] = int(float(data["vcpus"]))
 
         return self.make_model(diffsync_model, data)
 


### PR DESCRIPTION
Closes #85

When importing the data, the vCPU value, which is due to the json a string, is first casted to a float, and than to an int. 