### PR TITLE
Provide a default value for Interface.type

### DIFF
--- a/nautobot_netbox_importer/diffsync/models/abstract.py
+++ b/nautobot_netbox_importer/diffsync/models/abstract.py
@@ -9,7 +9,7 @@ import json
 import uuid
 
 from datetime import date, datetime
-from typing import Any, Mapping, Optional, Tuple, Union
+from typing import Any, Mapping, Optional, Tuple, Union, Iterable
 
 from diffsync import DiffSync, DiffSyncModel
 from django.core.exceptions import ObjectDoesNotExist, ValidationError as DjangoValidationError
@@ -568,7 +568,7 @@ class ComponentModel(CustomFieldModelMixin, NautobotBaseModel):
         if cls._type_choices is None:
             return values
         component_type_value = values["type"]
-        if component_type_value not in cls._type_choices:  # pylint: disable=no-member
+        if component_type_value not in cls._type_choices:  # pylint: disable=unsupported-membership-test
             values["type"] = "other"
             component_name = values["name"]
             device_name = None
@@ -599,7 +599,7 @@ class ComponentTemplateModel(CustomFieldModelMixin, NautobotBaseModel):
     label: str
     description: str
 
-    _type_choices = None
+    _type_choices: Optional[Iterable] = None
 
     @root_validator
     def invalid_type_to_other(cls, values):  # pylint: disable=no-self-argument,no-self-use
@@ -620,7 +620,7 @@ class ComponentTemplateModel(CustomFieldModelMixin, NautobotBaseModel):
         if cls._type_choices is None:
             return values
         component_type_value = values["type"]
-        if component_type_value not in cls._type_choices:
+        if component_type_value not in cls._type_choices:  # pylint: disable=unsupported-membership-test
             values["type"] = "other"
             component_name = values["name"]
             logger.warning(

--- a/nautobot_netbox_importer/diffsync/models/abstract.py
+++ b/nautobot_netbox_importer/diffsync/models/abstract.py
@@ -16,12 +16,13 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError as Django
 from django.db import models
 from django.db.utils import IntegrityError
 import netaddr
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, root_validator
 from pydantic.error_wrappers import ValidationError as PydanticValidationError
 import structlog
 
 from nautobot.extras.models import ObjectChange, ChangeLoggedModel
 from nautobot.utilities.utils import serialize_object
+from nautobot.dcim.models import Device
 
 from .references import (
     foreign_key_field,
@@ -546,6 +547,44 @@ class ComponentModel(CustomFieldModelMixin, NautobotBaseModel):
     label: str
     description: str
 
+    @root_validator
+    def invalid_type_to_other(cls, values):  # pylint: disable=no-self-argument,no-self-use
+        """
+        Default invalid `type` fields to use `other` type.
+
+        Almost all Component Models have a `type` field that uses a ChoiceSet to limit valid
+        choices. This uses Pydantic's root_validator to clean up the `type` data before loading
+        it into a Model instance. All invalid types will be changed to "other."
+
+        Two things must be done in order for a Component Model to inherit this behavoir:
+
+          1. The Model must define a `type` field.
+          2. The Model must define a class variable named `_type_choices`.
+
+        The `_type_choices` variable should be a set of the valid choices for the type per
+        Nautobot.
+        """
+        if "type" not in cls.__fields__ or "_type_choices" not in cls.__dict__:
+            return values
+        component_type_value = values["type"]
+        if component_type_value not in cls._type_choices:  # pylint: disable=no-member
+            values["type"] = "other"
+            component_name = values["name"]
+            device_name = None
+            device_pk = values["device"]
+            device = Device.objects.filter(pk=device_pk)
+            if device:
+                device_name = device.first().name
+            logger.warning(
+                f"Encountered a NetBox {cls._modelname}.type that is not valid in this version of Nautobot, will convert it",
+                component_type=cls._modelname,
+                component_name=component_name,
+                device_name_or_pk=device_name or device_pk,
+                netbox_type=component_type_value,
+                nautobot_type="other",
+            )
+        return values
+
 
 class ComponentTemplateModel(CustomFieldModelMixin, NautobotBaseModel):
     """Base class for Device component templates."""
@@ -556,6 +595,38 @@ class ComponentTemplateModel(CustomFieldModelMixin, NautobotBaseModel):
     name: str
     label: str
     description: str
+
+    @root_validator
+    def invalid_type_to_other(cls, values):  # pylint: disable=no-self-argument,no-self-use
+        """
+        Default invalid `type` fields to use `other` type.
+
+        Almost all Component Template Models have a `type` field that uses a ChoiceSet to limit valid
+        choices. This uses Pydantic's root_validator to clean up the `type` data before loading it
+        into a Model instance. All invalid types will be changed to "other."
+
+        Two things must be done in order for a Component Template Model to inherit this behavoir:
+
+          1. The Model must define a `type` field.
+          2. The Model must define a class variable named `_type_choices`.
+
+        The `_type_choices` variable should be a set of the valid choices for the type per
+        Nautobot.
+        """
+        if "type" not in cls.__fields__ or "_type_choices" not in cls.__dict__:
+            return values
+        component_type_value = values["type"]
+        if component_type_value not in cls._type_choices:  # pylint: disable=no-member
+            values["type"] = "other"
+            component_name = values["name"]
+            logger.warning(
+                f"Encountered a NetBox {cls._modelname}.type that is not valid in this version of Nautobot, will convert it",
+                component_type=cls._modelname,
+                component_name=component_name,
+                netbox_type=component_type_value,
+                nautobot_type="other",
+            )
+        return values
 
 
 class OrganizationalModel(  # pylint: disable=too-many-ancestors

--- a/nautobot_netbox_importer/diffsync/models/dcim.py
+++ b/nautobot_netbox_importer/diffsync/models/dcim.py
@@ -107,7 +107,7 @@ class Cable(StatusModelMixin, PrimaryModel):
             term_a_id = values["termination_a_id"]
             term_b_id = values["termination_b_id"]
             logger.warning(
-                f"Encountered a NetBox {cls._modelname}.type that is not valid in this version of Nautoobt, will convert it",
+                f"Encountered a NetBox {cls._modelname}.type that is not valid in this version of Nautobot, will convert it",
                 termination_a_id=term_a_id,
                 termination_b_id=term_b_id,
                 netbox_type=cable_type,
@@ -594,7 +594,7 @@ class Rack(StatusModelMixin, PrimaryModel):
             tenant = values.get("tenant")
             name = values["name"]
             logger.warning(
-                f"Encountered a NetBox {cls._modelname}.type that is not valid in this version of Nautoobt, will convert it",
+                f"Encountered a NetBox {cls._modelname}.type that is not valid in this version of Nautobot, will convert it",
                 site=site,
                 tenant=tenant,
                 name=name,

--- a/nautobot_netbox_importer/diffsync/models/dcim.py
+++ b/nautobot_netbox_importer/diffsync/models/dcim.py
@@ -313,7 +313,8 @@ class Interface(BaseInterfaceMixin, CableTerminationMixin, ComponentModel):
     tagged_vlans: List[VLANRef] = []
 
     @root_validator
-    def invalid_type_to_other(cls, values):
+    def invalid_type_to_other(cls, values):  # pylint: disable=no-self-argument,no-self-use
+        """Fixup Invalid Interface.type values for Nautobot."""
         int_type = values["type"]
         if int_type not in INTERFACE_TYPE_CHOICES:
             values["type"] = "other"

--- a/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
+++ b/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
@@ -3116,6 +3116,25 @@
     tagged_vlans: []
     type: 1000base-t
     untagged_vlan: null
+- model: dcim.interface
+  ids:
+    device:
+      ids:
+        name: "VC A Member 2"
+    name: mgmt10
+  fields:
+    cable: null
+    description: ''
+    enabled: true
+    label: 'Management 10'
+    lag: null
+    mac_address: null
+    mgmt_only: false
+    mode: ""
+    mtu: null
+    tagged_vlans: []
+    type: other
+    untagged_vlan: null
 - model: dcim.frontport
   ids:
     name: Device A Front Port

--- a/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
+++ b/nautobot_netbox_importer/tests/fixtures/nautobot_expectations.yaml
@@ -2716,7 +2716,7 @@
     description: ""
     label: "Model A Console Port 1"
     name: "Console Port 1"
-    type: rj-45
+    type: other
 - model: dcim.consoleserverport
   ids:
     device:
@@ -2771,7 +2771,7 @@
     description: ''
     label: 'Model A Console Server Port 1'
     name: Console Server Port 1
-    type: rj-45
+    type: other
 - model: dcim.powerport
   ids:
     device:
@@ -2797,7 +2797,7 @@
     label: ''
     maximum_draw: null
     name: Device B Power Port
-    type: iec-60320-c8
+    type: other
 - model: dcim.powerport
   ids:
     device:
@@ -2810,7 +2810,7 @@
     label: ''
     maximum_draw: null
     name: Device A Child Power Port
-    type: ''
+    type: 'iec-60320-c8'
 - model: dcim.powerport
   ids:
     device:
@@ -2934,7 +2934,7 @@
           ids:
             name: "VC A Member 2"
         name: "Power Port 1"
-    type: "nema-5-30r"
+    type: "other"
 - model: dcim.interface
   ids:
     device:
@@ -3218,7 +3218,7 @@
           ids:
             name: "VC A Member 2"
     rear_port_position: 1
-    type: 8p8c
+    type: other
 - model: dcim.rearport
   ids:
     name: "Device A Rear Port"
@@ -3278,7 +3278,7 @@
     description: ''
     label: "Model A Rear Port 1"
     positions: 2
-    type: 8p8c
+    type: other
 - model: dcim.devicebay
   ids:
     name: Device A Device Bay
@@ -3777,7 +3777,7 @@
 #     termination_a_type: 9
 #     termination_b_id: 2
 #     termination_b_type: 9
-#     type: ''
+#     type: 'cat5e'
 #   model: dcim.cable
 
 # - fields:
@@ -3791,7 +3791,7 @@
 #     termination_a_type: 10
 #     termination_b_id: 2
 #     termination_b_type: 10
-#     type: ''
+#     type: 'cat5e'
 #   model: dcim.cable
 
 # - fields:
@@ -3805,7 +3805,7 @@
 #     termination_a_type: 1
 #     termination_b_id: 1
 #     termination_b_type: 2
-#     type: ''
+#     type: 'cat5e'
 #   model: dcim.cable
 
 # - fields:
@@ -3819,7 +3819,7 @@
 #     termination_a_type: 3
 #     termination_b_id: 2
 #     termination_b_type: 4
-#     type: ''
+#     type: 'cat5e'
 #   model: dcim.cable
 
 # - fields:
@@ -3833,7 +3833,7 @@
 #     termination_a_type: 4
 #     termination_b_id: 2
 #     termination_b_type: 3
-#     type: ''
+#     type: 'cat5e'
 #   model: dcim.cable
 
 # - fields:
@@ -3861,8 +3861,22 @@
 #     termination_a_type: 11
 #     termination_b_id: 3
 #     termination_b_type: 3
-#     type: ''
+#     type: 'cat5e'
 #   model: dcim.cable
+
+#- fields:
+#    color: ''
+#    custom_field_data: {}
+#    label: ''
+#    length: null
+#    length_unit: ''
+#    status: connected
+#    termination_a_id: 1
+#    termination_a_type: 11
+#    termination_b_id: 3
+#    termination_b_type: 3
+#    type: 'other'
+#  model: dcim.cable
 
 # - fields:
 #     destination_id: 3
@@ -3993,6 +4007,16 @@
     label: "Model A Console Port 1"
     description: "Console Port template for Model A"
     type: "rj-45"
+- model: dcim.consoleporttemplate
+  ids:
+    name: "Console Port 2"
+  fields:
+    device_type:
+      ids:
+        model: "Model B"
+    label: "Model B Console Port 2"
+    description: "Console Port template for Model B"
+    type: "other"
 - model: dcim.consoleserverporttemplate
   ids:
     name: "Console Server Port 1"
@@ -4003,6 +4027,16 @@
     label: "Model A Console Server Port 1"
     description: "Console Server Port template for Model A"
     type: "rj-45"
+- model: dcim.consoleserverporttemplate
+  ids:
+    name: "Console Server Port 2"
+  fields:
+    device_type:
+      ids:
+        model: "Model B"
+    label: "Model B Console Server Port 2"
+    description: "Console Server Port template for Model B"
+    type: "other"
 - model: dcim.powerporttemplate
   ids:
     name: "Power Port 1"
@@ -4015,6 +4049,32 @@
     type: "nema-5-15p"
     maximum_draw: 100
     allocated_draw: 10
+- model: dcim.powerporttemplate
+  ids:
+    name: "Power Port 2"
+  fields:
+    device_type:
+      ids:
+        model: "Model B"
+    label: "Model B Power Port 2"
+    description: "Power Port template for Model B"
+    type: "other"
+    maximum_draw: 100
+    allocated_draw: 10
+- model: dcim.poweroutlettemplate
+  ids:
+    name: "Power Outlet 2"
+  fields:
+    device_type:
+      ids:
+        model: "Model B"
+    label: "Model B Power Outlet 2"
+    description: "Power Outlet template for Model B"
+    type: "other"
+    power_port:
+      ids:
+        name: "Power Port 2"
+    feed_leg: "B"
 - model: dcim.poweroutlettemplate
   ids:
     name: "Power Outlet 1"
@@ -4051,6 +4111,17 @@
     description: "Ethernet interface template for Model A"
     type: "100base-tx"
     mgmt_only: false
+- model: dcim.interfacetemplate
+  ids:
+    name: "eth1"
+  fields:
+    device_type:
+      ids:
+        model: "Model B"
+    label: "Ethernet 1"
+    description: "Ethernet interface template for Model B"
+    type: "other"
+    mgmt_only: false
 - model: dcim.frontporttemplate
   ids:
     name: "Front Port 1"
@@ -4065,6 +4136,20 @@
       ids:
         name: "Rear Port 1"
     rear_port_position: 1
+- model: dcim.frontporttemplate
+  ids:
+    name: "Front Port 2"
+  fields:
+    device_type:
+      ids:
+        model: "Model B"
+    label: "Model B Front Port 2"
+    description: "Front Port template for Model B"
+    type: "other"
+    rear_port:
+      ids:
+        name: "Rear Port 2"
+    rear_port_position: 2
 - model: dcim.rearporttemplate
   ids:
     name: "Rear Port 1"
@@ -4075,6 +4160,17 @@
     label: "Model A Rear Port 1"
     description: "Rear Port template for Model A"
     type: "8p8c"
+    positions: 2
+- model: dcim.rearporttemplate
+  ids:
+    name: "Rear Port 2"
+  fields:
+    device_type:
+      ids:
+        model: "Model B"
+    label: "Model B Rear Port 2"
+    description: "Rear Port template for Model B"
+    type: "other"
     positions: 2
 - model: dcim.devicebaytemplate
   ids:
@@ -4244,7 +4340,7 @@
     tenant:
       ids:
         name: "Tenant B"
-    type: ''
+    type: 'other'
     u_height: 42
     width: 19
 - model: dcim.rackreservation

--- a/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
+++ b/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
@@ -4418,6 +4418,30 @@
         }
     },
     {
+        "model": "dcim.interface",
+        "pk": 10,
+        "fields": {
+            "device": 6,
+            "name": "mgmt10",
+            "label": "Management 10",
+            "description": "",
+            "cable": null,
+            "_cable_peer_type": null,
+            "_cable_peer_id": null,
+            "_path": null,
+            "enabled": true,
+            "mac_address": null,
+            "mtu": null,
+            "mode": "",
+            "_name": "9999999999999999mgmt000010............",
+            "lag": null,
+            "type": "DNE",
+            "mgmt_only": false,
+            "untagged_vlan": null,
+            "tagged_vlans": []
+        }
+    },
+    {
         "model": "dcim.frontport",
         "pk": 1,
         "fields": {

--- a/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
+++ b/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
@@ -3918,7 +3918,7 @@
             "_cable_peer_type": null,
             "_cable_peer_id": null,
             "_path": null,
-            "type": "DNE"
+            "type": "does-not-exist"
         }
     },
     {
@@ -3998,7 +3998,7 @@
             "_cable_peer_type": null,
             "_cable_peer_id": null,
             "_path": null,
-            "type": "DNE"
+            "type": "does-not-exist"
         }
     },
     {
@@ -4032,7 +4032,7 @@
             "_cable_peer_type": 4,
             "_cable_peer_id": 1,
             "_path": 8,
-            "type": "DNE",
+            "type": "does-not-exist",
             "maximum_draw": null,
             "allocated_draw": null
         }
@@ -4194,7 +4194,7 @@
             "_cable_peer_type": null,
             "_cable_peer_id": null,
             "_path": null,
-            "type": "DNE",
+            "type": "does-not-exist",
             "power_port": 6,
             "feed_leg": "A"
         }
@@ -4435,7 +4435,7 @@
             "mode": "",
             "_name": "9999999999999999mgmt000010............",
             "lag": null,
-            "type": "DNE",
+            "type": "does-not-exist",
             "mgmt_only": false,
             "untagged_vlan": null,
             "tagged_vlans": []
@@ -4521,7 +4521,7 @@
             "cable": null,
             "_cable_peer_type": null,
             "_cable_peer_id": null,
-            "type": "DNE",
+            "type": "does-not-exist",
             "rear_port": 5,
             "rear_port_position": 1
         }
@@ -4602,7 +4602,7 @@
             "cable": null,
             "_cable_peer_type": null,
             "_cable_peer_id": null,
-            "type": "DNE",
+            "type": "does-not-exist",
             "positions": 2
         }
     },
@@ -5272,7 +5272,7 @@
             "termination_a_id": 1,
             "termination_b_type": 7,
             "termination_b_id": 3,
-            "type": "DNE",
+            "type": "does-not-exist",
             "status": "connected",
             "label": "Circuit A to Circuit B",
             "color": "",
@@ -5460,7 +5460,7 @@
             "_name": "Console Port 00000002",
             "label": "Model B Console Port 2",
             "description": "Console Port template for Model B",
-            "type": "DNE"
+            "type": "does-not-exist"
         }
     },
     {
@@ -5484,7 +5484,7 @@
             "_name": "Console Server Port 00000002",
             "label": "Model B Console Server Port 2",
             "description": "Console Server Port template for Model B",
-            "type": "DNE"
+            "type": "does-not-exist"
         }
     },
     {
@@ -5510,7 +5510,7 @@
             "_name": "Power Port 00000002",
             "label": "Model B Power Port 2",
             "description": "Power Port template for Model B",
-            "type": "DNE",
+            "type": "does-not-exist",
             "maximum_draw": 100,
             "allocated_draw": 10
         }
@@ -5538,7 +5538,7 @@
             "_name": "Power Outlet 00000002",
             "label": "Model B Power Outlet 2",
             "description": "Power Outlet template for Model B",
-            "type": "DNE",
+            "type": "does-not-exist",
             "power_port": 2,
             "feed_leg": "B"
         }
@@ -5578,7 +5578,7 @@
             "label": "Ethernet 1",
             "description": "Ethernet interface template for Model B",
             "_name": "9999999999999999eth000001............",
-            "type": "DNE",
+            "type": "does-not-exist",
             "mgmt_only": false
         }
     },
@@ -5605,7 +5605,7 @@
             "_name": "Front Port 00000002",
             "label": "Model B Front Port 2",
             "description": "Front Port template for Model B",
-            "type": "DNE",
+            "type": "does-not-exist",
             "rear_port": 2,
             "rear_port_position": 2
         }
@@ -5632,7 +5632,7 @@
             "_name": "Rear Port 00000002",
             "label": "Model B Rear Port 2",
             "description": "Rear Port template for Model B",
-            "type": "DNE",
+            "type": "does-not-exist",
             "positions": 2
         }
     },
@@ -5823,7 +5823,7 @@
             "role": 2,
             "serial": "",
             "asset_tag": null,
-            "type": "DNE",
+            "type": "does-not-exist",
             "width": 19,
             "u_height": 42,
             "desc_units": true,

--- a/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
+++ b/nautobot_netbox_importer/tests/fixtures/netbox_dump.json
@@ -3918,7 +3918,7 @@
             "_cable_peer_type": null,
             "_cable_peer_id": null,
             "_path": null,
-            "type": "rj-45"
+            "type": "DNE"
         }
     },
     {
@@ -3998,7 +3998,7 @@
             "_cable_peer_type": null,
             "_cable_peer_id": null,
             "_path": null,
-            "type": "rj-45"
+            "type": "DNE"
         }
     },
     {
@@ -4032,7 +4032,7 @@
             "_cable_peer_type": 4,
             "_cable_peer_id": 1,
             "_path": 8,
-            "type": "iec-60320-c8",
+            "type": "DNE",
             "maximum_draw": null,
             "allocated_draw": null
         }
@@ -4050,7 +4050,7 @@
             "_cable_peer_type": 11,
             "_cable_peer_id": 1,
             "_path": 12,
-            "type": "",
+            "type": "iec-60320-c8",
             "maximum_draw": null,
             "allocated_draw": null
         }
@@ -4194,7 +4194,7 @@
             "_cable_peer_type": null,
             "_cable_peer_id": null,
             "_path": null,
-            "type": "nema-5-30r",
+            "type": "DNE",
             "power_port": 6,
             "feed_leg": "A"
         }
@@ -4521,7 +4521,7 @@
             "cable": null,
             "_cable_peer_type": null,
             "_cable_peer_id": null,
-            "type": "8p8c",
+            "type": "DNE",
             "rear_port": 5,
             "rear_port_position": 1
         }
@@ -4602,7 +4602,7 @@
             "cable": null,
             "_cable_peer_type": null,
             "_cable_peer_id": null,
-            "type": "8p8c",
+            "type": "DNE",
             "positions": 2
         }
     },
@@ -5118,7 +5118,7 @@
             "termination_a_id": 1,
             "termination_b_type": 9,
             "termination_b_id": 2,
-            "type": "",
+            "type": "cat5e",
             "status": "connected",
             "label": "",
             "color": "",
@@ -5140,7 +5140,7 @@
             "termination_a_id": 1,
             "termination_b_type": 10,
             "termination_b_id": 2,
-            "type": "",
+            "type": "cat5e",
             "status": "planned",
             "label": "",
             "color": "",
@@ -5162,7 +5162,7 @@
             "termination_a_id": 1,
             "termination_b_type": 2,
             "termination_b_id": 1,
-            "type": "",
+            "type": "cat5e",
             "status": "connected",
             "label": "",
             "color": "",
@@ -5184,7 +5184,7 @@
             "termination_a_id": 1,
             "termination_b_type": 4,
             "termination_b_id": 2,
-            "type": "",
+            "type": "cat5e",
             "status": "connected",
             "label": "",
             "color": "",
@@ -5206,7 +5206,7 @@
             "termination_a_id": 1,
             "termination_b_type": 3,
             "termination_b_id": 2,
-            "type": "",
+            "type": "cat5e",
             "status": "decommissioning",
             "label": "",
             "color": "",
@@ -5228,7 +5228,7 @@
             "termination_a_id": 1,
             "termination_b_type": 3,
             "termination_b_id": 3,
-            "type": "",
+            "type": "cat5e",
             "status": "connected",
             "label": "",
             "color": "",
@@ -5250,7 +5250,29 @@
             "termination_a_id": 1,
             "termination_b_type": 7,
             "termination_b_id": 3,
-            "type": "",
+            "type": "cat5e",
+            "status": "connected",
+            "label": "Circuit A to Circuit B",
+            "color": "",
+            "length": null,
+            "length_unit": "",
+            "_abs_length": null,
+            "_termination_a_device": null,
+            "_termination_b_device": null
+        }
+    },
+    {
+        "model": "dcim.cable",
+        "pk": 10,
+        "fields": {
+            "created": "2021-03-23",
+            "last_updated": "2021-03-23T18:54:41.484Z",
+            "custom_field_data": {},
+            "termination_a_type": 7,
+            "termination_a_id": 1,
+            "termination_b_type": 7,
+            "termination_b_id": 3,
+            "type": "DNE",
             "status": "connected",
             "label": "Circuit A to Circuit B",
             "color": "",
@@ -5430,6 +5452,18 @@
         }
     },
     {
+        "model": "dcim.consoleporttemplate",
+        "pk": 2,
+        "fields": {
+            "device_type": 3,
+            "name": "Console Port 2",
+            "_name": "Console Port 00000002",
+            "label": "Model B Console Port 2",
+            "description": "Console Port template for Model B",
+            "type": "DNE"
+        }
+    },
+    {
         "model": "dcim.consoleserverporttemplate",
         "pk": 1,
         "fields": {
@@ -5439,6 +5473,18 @@
             "label": "Model A Console Server Port 1",
             "description": "Console Server Port template for Model A",
             "type": "rj-45"
+        }
+    },
+    {
+        "model": "dcim.consoleserverporttemplate",
+        "pk": 2,
+        "fields": {
+            "device_type": 3,
+            "name": "Console Server Port 2",
+            "_name": "Console Server Port 00000002",
+            "label": "Model B Console Server Port 2",
+            "description": "Console Server Port template for Model B",
+            "type": "DNE"
         }
     },
     {
@@ -5456,6 +5502,20 @@
         }
     },
     {
+        "model": "dcim.powerporttemplate",
+        "pk": 2,
+        "fields": {
+            "device_type": 3,
+            "name": "Power Port 2",
+            "_name": "Power Port 00000002",
+            "label": "Model B Power Port 2",
+            "description": "Power Port template for Model B",
+            "type": "DNE",
+            "maximum_draw": 100,
+            "allocated_draw": 10
+        }
+    },
+    {
         "model": "dcim.poweroutlettemplate",
         "pk": 1,
         "fields": {
@@ -5467,6 +5527,20 @@
             "type": "nema-5-30r",
             "power_port": 1,
             "feed_leg": "A"
+        }
+    },
+    {
+        "model": "dcim.poweroutlettemplate",
+        "pk": 2,
+        "fields": {
+            "device_type": 3,
+            "name": "Power Outlet 2",
+            "_name": "Power Outlet 00000002",
+            "label": "Model B Power Outlet 2",
+            "description": "Power Outlet template for Model B",
+            "type": "DNE",
+            "power_port": 2,
+            "feed_leg": "B"
         }
     },
     {
@@ -5496,6 +5570,19 @@
         }
     },
     {
+        "model": "dcim.interfacetemplate",
+        "pk": 3,
+        "fields": {
+            "device_type": 3,
+            "name": "eth1",
+            "label": "Ethernet 1",
+            "description": "Ethernet interface template for Model B",
+            "_name": "9999999999999999eth000001............",
+            "type": "DNE",
+            "mgmt_only": false
+        }
+    },
+    {
         "model": "dcim.frontporttemplate",
         "pk": 1,
         "fields": {
@@ -5510,6 +5597,20 @@
         }
     },
     {
+        "model": "dcim.frontporttemplate",
+        "pk": 2,
+        "fields": {
+            "device_type": 3,
+            "name": "Front Port 2",
+            "_name": "Front Port 00000002",
+            "label": "Model B Front Port 2",
+            "description": "Front Port template for Model B",
+            "type": "DNE",
+            "rear_port": 2,
+            "rear_port_position": 2
+        }
+    },
+    {
         "model": "dcim.rearporttemplate",
         "pk": 1,
         "fields": {
@@ -5519,6 +5620,19 @@
             "label": "Model A Rear Port 1",
             "description": "Rear Port template for Model A",
             "type": "8p8c",
+            "positions": 2
+        }
+    },
+    {
+        "model": "dcim.rearporttemplate",
+        "pk": 2,
+        "fields": {
+            "device_type": 3,
+            "name": "Rear Port 2",
+            "_name": "Rear Port 00000002",
+            "label": "Model B Rear Port 2",
+            "description": "Rear Port template for Model B",
+            "type": "DNE",
             "positions": 2
         }
     },
@@ -5709,7 +5823,7 @@
             "role": 2,
             "serial": "",
             "asset_tag": null,
-            "type": "",
+            "type": "DNE",
             "width": 19,
             "u_height": 42,
             "desc_units": true,


### PR DESCRIPTION
Netbox and Nautobot have different choice options for the Interface.type field. This defaults to using the "other" type in Nautobot when the Netbox type is not supported by Nautobot.